### PR TITLE
fix: require agent-vault/README.md in session-start reads

### DIFF
--- a/scaffold/agent-vault/AGENTS.md
+++ b/scaffold/agent-vault/AGENTS.md
@@ -25,6 +25,7 @@
 - Read `agent-vault/context-log.md`.
 - Read `agent-vault/plan.md`.
 - Read `agent-vault/coding-standards.md`.
+- Read `agent-vault/README.md`.
 - Read recent notes in `agent-vault/design-log/`.
 - Read recent notes in `agent-vault/context/handoffs/`.
 - Read `agent-vault/lessons.md` (if it exists).

--- a/scaffold/agent-vault/shared-rules.md
+++ b/scaffold/agent-vault/shared-rules.md
@@ -20,6 +20,7 @@
 - Read `agent-vault/context-log.md`.
 - Read `agent-vault/plan.md`.
 - Read `agent-vault/coding-standards.md`.
+- Read `agent-vault/README.md`.
 - Read recent notes in `agent-vault/design-log/`.
 - Read recent notes in `agent-vault/context/handoffs/`.
 - Read `agent-vault/lessons.md` (if it exists).


### PR DESCRIPTION
## Summary
- add `Read `agent-vault/README.md`.` to the `## Session Start - Required` checklist in `scaffold/agent-vault/shared-rules.md`
- keep `scaffold/agent-vault/AGENTS.md` in sync with the same required-read line

## Why
- `agent-vault/README.md` contains essential project context and should be a mandatory startup read
- migrate-root output dropped this requirement; this restores the intended behavior

## Validation
- verified both files contain the new required-read line
- confirmed diff is limited to the two expected one-line insertions