### PR TITLE
Fix root wrappers to include migrated agent-specific guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Without this flag, `new-project.sh` leaves pre-existing root files unchanged and
 
 It also creates project-root wrappers when missing:
 - `<repo-path>/AGENTS.md` -> contains PR review guidance (inline) for Codex GitHub reviews and points workflow execution to `agent-vault/AGENTS.md`
-- `<repo-path>/CLAUDE.md` -> imports `agent-vault/CLAUDE.md`, `agent-vault/shared-rules.md`, and `agent-vault/review-policy.md`
-- `<repo-path>/GEMINI.md` -> imports `agent-vault/GEMINI.md`, `agent-vault/shared-rules.md`, and `agent-vault/review-policy.md`
+- `<repo-path>/CLAUDE.md` -> imports `agent-vault/CLAUDE.md` and `agent-vault/review-policy.md`
+- `<repo-path>/GEMINI.md` -> imports `agent-vault/GEMINI.md` and `agent-vault/review-policy.md`
 
 If root files already exist, the script leaves them unchanged unless `--migrate-existing-root-md` is provided.

--- a/scaffold/root/CLAUDE.md
+++ b/scaffold/root/CLAUDE.md
@@ -2,5 +2,4 @@
 <!-- agent-vault-managed: root-wrapper; file=CLAUDE.md -->
 
 @agent-vault/CLAUDE.md
-@agent-vault/shared-rules.md
 @agent-vault/review-policy.md

--- a/scaffold/root/GEMINI.md
+++ b/scaffold/root/GEMINI.md
@@ -2,5 +2,4 @@
 <!-- agent-vault-managed: root-wrapper; file=GEMINI.md -->
 
 @agent-vault/GEMINI.md
-@agent-vault/shared-rules.md
 @agent-vault/review-policy.md


### PR DESCRIPTION
## Summary
- update `scaffold/root/CLAUDE.md` to include `@agent-vault/CLAUDE.md`
- update `scaffold/root/GEMINI.md` to include `@agent-vault/GEMINI.md`
- standardize Gemini root wrapper include paths to `@agent-vault/...` format
- refresh README wrapper/migration docs to match generated output

## Why
When `new-project.sh --migrate-existing-root-md` appends legacy root guidance into `agent-vault/CLAUDE.md` and `agent-vault/GEMINI.md`, root wrappers should include those files so migrated context is active in root entrypoint sessions.

## Validation
- generated a temp repo and ran `scripts/new-project.sh <name> <repo> --migrate-existing-root-md`
- verified root `CLAUDE.md` and `GEMINI.md` include `agent-vault/CLAUDE.md` and `agent-vault/GEMINI.md`
- verified migrated legacy sections are present in vault policy files
- ran `scripts/update-project.sh <repo>` smoke test against old managed wrappers and confirmed wrappers were updated