### PR TITLE
Expand policy mirror checks to full mirrored ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This repository intentionally keeps three mirrored policy blocks for compatibili
 - `AGENTS.md` mirrors the review section from `scaffold/agent-vault/review-policy.md` (with a repo-local path alias normalization in the check).
 - `scaffold/root/AGENTS.md` mirrors the review section from `scaffold/agent-vault/review-policy.md`.
 - `scaffold/agent-vault/AGENTS.md` mirrors shared workflow rules from `scaffold/agent-vault/shared-rules.md`.
-The check compares each mirrored block from its start heading through EOF so coverage includes all mirrored top-level sections.
+- Each check compares its mirrored block from the start heading through EOF, covering all mirrored top-level sections.
 
 To prevent accidental drift, run:
 - `bash scripts/check-policy-mirrors.sh`

--- a/scripts/check-policy-mirrors.sh
+++ b/scripts/check-policy-mirrors.sh
@@ -22,6 +22,8 @@ extract_from_heading() {
       echo "Error: heading must start with markdown # characters: $heading" >&2
       return 1
     fi
+  else
+    heading_level=0
   fi
 
   awk -v heading="$heading" -v range_mode="$range_mode" -v heading_level="$heading_level" '


### PR DESCRIPTION
> 🤖 Prepared by Codex (GPT-5) · via Codex CLI

## Summary
- Problem:
  - Existing mirror checks validated only a single top-level section per mirror pair.
  - This left significant mirrored policy content unchecked and could create false confidence.
- Approach:
  - Added extraction-mode support to `scripts/check-policy-mirrors.sh`.
  - Switched all active checks to `to_eof` mode so each check covers full mirrored ranges from start heading through EOF.
  - Updated README wording to reflect full-range coverage.
- Outcome:
  - Drift checks now cover all mirrored top-level sections for each configured pair.

## Changes
- `scripts/check-policy-mirrors.sh`:
  - Added `range_mode` support (`section` / `to_eof`) in `extract_from_heading`.
  - Added `extraction_mode` argument in `compare_mirrored_sections`.
  - Updated all three active checks to `to_eof`.
- `README.md`:
  - Clarified that checks compare mirrored ranges from start heading through EOF.

## Validation
- `bash -n scripts/check-policy-mirrors.sh`: pass
- `bash scripts/check-policy-mirrors.sh`: pass
  - `OK: scaffold/root/AGENTS.md ... (full mirrored range)`
  - `OK: scaffold/agent-vault/AGENTS.md ... (full mirrored range)`
  - `OK: AGENTS.md ... (full mirrored range; normalized for repo-local path alias)`

## Risks and Rollback
- Risk:
  - CI may now fail for drifts previously undetected.
- Mitigation:
  - Failure output includes pair labels and unified diffs to reconcile quickly.
- Rollback:
  - Revert commit `4844d31`.

## Docs Consistency
- `docs/design.md`: No impact (repository has no `docs/design.md`; no architecture change).
- `README.md`: Updated to clarify full-range mirror-check coverage.

## Review Feedback Mapping (if applicable)
| # | Finding | Status | Evidence / Rationale |
|---|---------|--------|----------------------|
| 1 | Single-section checks leave major mirrored content unchecked | Resolved | `4844d31`; all active checks now use `to_eof` full-range extraction |

## Follow-Ups
- [ ] None
