### PR TITLE
Align root entrypoint docs with artifact workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,9 @@ This repository holds reusable scaffold files for `agent-vault/`.
 - Do not store project-specific context in this repository.
 
 ## Target Project Usage
-In generated project vaults, use:
-- `agent-vault/context-log.md` as canonical handoff memory
-- `agent-vault/plan.md` and `agent-vault/coding-standards.md` as execution constraints
-- `agent-vault/design-log/` and `agent-vault/context/handoffs/` for session transfer
+In generated project vaults:
+- `agent-vault/Templates/` is template source only. Instantiated notes belong in canonical runtime files under `agent-vault/`.
+- Start substantive work by reading `agent-vault/README.md`, `agent-vault/context-log.md`, `agent-vault/plan.md`, and `agent-vault/coding-standards.md`.
+- Skim `agent-vault/open-questions.md` for blockers and `agent-vault/decision-log.md` for active decisions relevant to the task.
+- Use `agent-vault/context-log.md` as canonical cross-session memory.
+- Use `agent-vault/daily/`, `agent-vault/design-log/`, `agent-vault/context/handoffs/`, and `agent-vault/decisions/` for runtime artifacts when the workflow calls for them.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,9 @@ This repository holds reusable scaffold files for `agent-vault/`.
 - Do not store project-specific context in this repository.
 
 ## Target Project Usage
-In generated project vaults, use:
-- `agent-vault/context-log.md` as canonical handoff memory
-- `agent-vault/plan.md` and `agent-vault/coding-standards.md` as execution constraints
-- `agent-vault/design-log/` and `agent-vault/context/handoffs/` for session transfer
+In generated project vaults:
+- `agent-vault/Templates/` is template source only. Instantiated notes belong in canonical runtime files under `agent-vault/`.
+- Start substantive work by reading `agent-vault/README.md`, `agent-vault/context-log.md`, `agent-vault/plan.md`, and `agent-vault/coding-standards.md`.
+- Skim `agent-vault/open-questions.md` for blockers and `agent-vault/decision-log.md` for active decisions relevant to the task.
+- Use `agent-vault/context-log.md` as canonical cross-session memory.
+- Use `agent-vault/daily/`, `agent-vault/design-log/`, `agent-vault/context/handoffs/`, and `agent-vault/decisions/` for runtime artifacts when the workflow calls for them.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ This repository intentionally keeps three mirrored policy blocks for compatibili
 - `scaffold/root/AGENTS.md` mirrors the review section from `scaffold/agent-vault/review-policy.md`.
 - `scaffold/agent-vault/AGENTS.md` mirrors shared workflow rules from `scaffold/agent-vault/shared-rules.md`.
 - Each check compares its mirrored block from the start heading through EOF, covering all mirrored top-level sections.
+- Root `CLAUDE.md` and `GEMINI.md` in this template repo are lightweight repo-local helper docs and are not drift-checked.
+- `scaffold/root/CLAUDE.md` and `scaffold/root/GEMINI.md` remain thin wrappers over `agent-vault/*.md` plus `review-policy.md`; no additional drift enforcement is added for them.
 
 To prevent accidental drift, run:
 - `bash scripts/check-policy-mirrors.sh`

--- a/scaffold/root/CLAUDE.md
+++ b/scaffold/root/CLAUDE.md
@@ -1,5 +1,8 @@
 # CLAUDE.md
 <!-- agent-vault-managed: root-wrapper; file=CLAUDE.md -->
 
+Project workflow lives in `agent-vault/CLAUDE.md`.
+Runtime artifacts live under `agent-vault/`; `agent-vault/Templates/` is source-only.
+
 @agent-vault/CLAUDE.md
 @agent-vault/review-policy.md

--- a/scaffold/root/GEMINI.md
+++ b/scaffold/root/GEMINI.md
@@ -1,5 +1,8 @@
 # GEMINI.md
 <!-- agent-vault-managed: root-wrapper; file=GEMINI.md -->
 
+Project workflow lives in `agent-vault/GEMINI.md`.
+Runtime artifacts live under `agent-vault/`; `agent-vault/Templates/` is source-only.
+
 @agent-vault/GEMINI.md
 @agent-vault/review-policy.md


### PR DESCRIPTION
## Summary
- update the root `CLAUDE.md` and `GEMINI.md` helper docs to reflect the explicit artifact workflow introduced in PR #15
- clarify in `scaffold/root/CLAUDE.md` and `scaffold/root/GEMINI.md` that runtime artifacts live under `agent-vault/` and `Templates/` is source-only
- document in `README.md` that no additional drift enforcement is being added for the root helper docs

## Validation
- `bash scripts/check-policy-mirrors.sh`
- `git diff --check origin/main...HEAD`

Closes #16