### PR TITLE
Manage folder README guidance during project sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ CI also enforces this via `.github/workflows/policy-mirror-check.yml` on pull re
   - `<repo>/agent-vault/CLAUDE.md`
   - `<repo>/agent-vault/GEMINI.md`
   - `<repo>/agent-vault/handoff.md`
+  - `<repo>/agent-vault/design-log/README.md`
+  - `<repo>/agent-vault/context/handoffs/README.md`
+  - `<repo>/agent-vault/decisions/README.md`
+  - `<repo>/agent-vault/daily/README.md`
 - Root wrappers (managed only when the root file has the `agent-vault-managed` marker):
   - `<repo>/AGENTS.md`
   - `<repo>/CLAUDE.md`
@@ -86,7 +90,6 @@ CI also enforces this via `.github/workflows/policy-mirror-check.yml` on pull re
   - `<repo>/.github/pull_request_template.md`
   - `<repo>/docs/design.md`
   - `<repo>/agent-vault/lessons.md`
-  - `<repo>/agent-vault/daily/README.md`
 
 If an existing root policy file does not have the managed marker, `update-project.sh` leaves it unchanged and reports a skip notice suggesting `--migrate-root`.
 
@@ -151,6 +154,6 @@ It also creates project-root files when missing:
 - `<repo-path>/GEMINI.md` -> imports `agent-vault/GEMINI.md` and `agent-vault/review-policy.md`
 - `<repo-path>/docs/design.md` -> starter architecture/design document with embedded Mermaid diagrams
 - `<repo-path>/.github/pull_request_template.md` -> standardized agent PR body template
-- Bootstrap behavior: `new-project.sh` hydrates project metadata placeholders (`repo_reference`, active branch, dates) in the baseline `agent-vault/` docs, seeds non-empty baseline content in required session-start docs (`agent-vault/README.md`, `plan.md`, `coding-standards.md`, `context-log.md`, and `design-log/README.md`), and seeds `docs/design.md` as a starter design document.
+- Bootstrap behavior: `new-project.sh` hydrates project metadata placeholders (`repo_reference`, active branch, dates) in the baseline `agent-vault/` docs, seeds non-empty baseline content in required core docs (`agent-vault/README.md`, `plan.md`, `coding-standards.md`, and `context-log.md`), and copies scaffold helper docs such as `agent-vault/design-log/README.md` plus `docs/design.md`.
 
 If root files already exist, the script leaves them unchanged unless `--migrate-existing-root-md` is provided.

--- a/scaffold/agent-vault/design-log/README.md
+++ b/scaffold/agent-vault/design-log/README.md
@@ -1,18 +1,16 @@
 # Design Log
 
-## Current State Summary
-- Project: `__PROJECT_NAME__`
-- Working repo: `__REPO_PATH__`
-- Current branch at bootstrap: `__ACTIVE_BRANCH__`
-- Phase: planning and setup baseline
-- Canonical references:
-  - `agent-vault/plan.md`
-  - `agent-vault/open-questions.md`
-  - `agent-vault/context-log.md`
+Use this folder for short session notes that capture implementation work, investigations, and decisions-in-progress.
 
-Add one short note per substantive work session.
+Current project state belongs in the newest session notes, not in this README.
 - Read the newest 3 notes first during session start.
+- Use each note to capture the branch, relevant files, validation run, and open follow-ups when that context matters.
 - When a session produces a handoff note or decision record, link it from the session note.
+
+Canonical references:
+- `agent-vault/plan.md`
+- `agent-vault/open-questions.md`
+- `agent-vault/context-log.md`
 
 Suggested filename:
 - `YYYY-MM-DD-HHMM-<topic>.md`

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -290,6 +290,21 @@ if [[ ! -f "$scaffold_dir/handoff.md" ]]; then
   exit 1
 fi
 
+if [[ ! -f "$scaffold_dir/design-log/README.md" ]]; then
+  echo "Error: missing scaffold file: $scaffold_dir/design-log/README.md"
+  exit 1
+fi
+
+if [[ ! -f "$scaffold_dir/context/handoffs/README.md" ]]; then
+  echo "Error: missing scaffold file: $scaffold_dir/context/handoffs/README.md"
+  exit 1
+fi
+
+if [[ ! -f "$scaffold_dir/decisions/README.md" ]]; then
+  echo "Error: missing scaffold file: $scaffold_dir/decisions/README.md"
+  exit 1
+fi
+
 if [[ ! -f "$scaffold_dir/daily/README.md" ]]; then
   echo "Error: missing scaffold file: $scaffold_dir/daily/README.md"
   exit 1

--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -120,6 +120,9 @@ for required in \
   "$vault_scaffold_dir/review-policy.md" \
   "$vault_scaffold_dir/handoff.md" \
   "$vault_scaffold_dir/lessons.md" \
+  "$vault_scaffold_dir/design-log/README.md" \
+  "$vault_scaffold_dir/context/handoffs/README.md" \
+  "$vault_scaffold_dir/decisions/README.md" \
   "$vault_scaffold_dir/daily/README.md"
 do
   if [[ ! -f "$required" ]]; then
@@ -187,6 +190,10 @@ preflight_symlink_checks() {
   assert_not_symlink "$project_dir/shared-rules.md" "agent-vault/shared-rules.md"
   assert_not_symlink "$project_dir/review-policy.md" "agent-vault/review-policy.md"
   assert_not_symlink "$project_dir/handoff.md" "agent-vault/handoff.md"
+  assert_not_symlink "$project_dir/design-log/README.md" "agent-vault/design-log/README.md"
+  assert_not_symlink "$project_dir/context/handoffs/README.md" "agent-vault/context/handoffs/README.md"
+  assert_not_symlink "$project_dir/decisions/README.md" "agent-vault/decisions/README.md"
+  assert_not_symlink "$project_dir/daily/README.md" "agent-vault/daily/README.md"
   assert_not_symlink "$canonical_repo_path/.gitignore" ".gitignore"
 }
 
@@ -437,9 +444,12 @@ sync_managed_file "$vault_scaffold_dir/AGENTS.md" "$project_dir/AGENTS.md"
 sync_managed_file "$vault_scaffold_dir/CLAUDE.md" "$project_dir/CLAUDE.md"
 sync_managed_file "$vault_scaffold_dir/GEMINI.md" "$project_dir/GEMINI.md"
 sync_managed_file "$vault_scaffold_dir/handoff.md" "$project_dir/handoff.md"
+sync_managed_file "$vault_scaffold_dir/design-log/README.md" "$project_dir/design-log/README.md"
+sync_managed_file "$vault_scaffold_dir/context/handoffs/README.md" "$project_dir/context/handoffs/README.md"
+sync_managed_file "$vault_scaffold_dir/decisions/README.md" "$project_dir/decisions/README.md"
+sync_managed_file "$vault_scaffold_dir/daily/README.md" "$project_dir/daily/README.md"
 
 seed_if_missing "$vault_scaffold_dir/lessons.md" "$project_dir/lessons.md"
-seed_if_missing "$vault_scaffold_dir/daily/README.md" "$project_dir/daily/README.md"
 sync_template_files "$vault_scaffold_dir/Templates" "$project_dir/Templates"
 
 ensure_obsidian_gitignore "$canonical_repo_path"


### PR DESCRIPTION
## Summary
- manage the folder README guidance files during `update-project.sh` syncs
- make `design-log/README.md` generic so it can be safely managed in existing repos
- document the four folder READMEs as always-managed scaffold files

## Validation
- `bash scripts/check-policy-mirrors.sh`
- `bash -n scripts/new-project.sh scripts/update-project.sh scripts/check-policy-mirrors.sh`
- `git diff --check`
- temp-repo smoke test verifying stale folder READMEs are restored and no bootstrap placeholders are reintroduced

Closes #20