### PR TITLE
Ignore local agent-vault update backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ When running `update-project.sh` with `--migrate-root`, unmanaged root wrappers 
 When a managed file changes, the script backs up the previous version under:
 - `<repo>/agent-vault/context/updates/<timestamp>/...`
 
-Both scripts also ensure root `.gitignore` includes Obsidian-safe ignore entries (added only when missing):
+Both scripts also ensure root `.gitignore` includes managed local-only ignore entries (added only when missing):
 - `.obsidian/workspace.json`
 - `.obsidian/app.json`
 - `.obsidian/appearance.json`
@@ -108,6 +108,7 @@ Both scripts also ensure root `.gitignore` includes Obsidian-safe ignore entries
 - `.obsidian/cache/`
 - `.obsidian/backup/`
 - `.obsidian/plugins/*/data.json`
+- `/agent-vault/context/updates/`
 
 ## Migrating Existing Root Policy Files
 When running `new-project.sh` with `--migrate-existing-root-md`:

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -123,7 +123,7 @@ append_migrated_root_content() {
   } >> "$destination_path"
 }
 
-OBSIDIAN_GITIGNORE_LINES=(
+MANAGED_GITIGNORE_LINES=(
   "# Obsidian -- machine-specific & volatile files (ignore these)"
   ".obsidian/workspace.json"
   ".obsidian/app.json"
@@ -133,13 +133,15 @@ OBSIDIAN_GITIGNORE_LINES=(
   ".obsidian/backup/"
   "# Plugin data (can contain API keys or large caches)"
   ".obsidian/plugins/*/data.json"
+  "# Agent Vault -- local sync and migration backups (ignore these)"
+  "/agent-vault/context/updates/"
 )
 
 ROOT_AGENTS_MARKER="<!-- agent-vault-managed: root-wrapper; file=AGENTS.md -->"
 ROOT_CLAUDE_MARKER="<!-- agent-vault-managed: root-wrapper; file=CLAUDE.md -->"
 ROOT_GEMINI_MARKER="<!-- agent-vault-managed: root-wrapper; file=GEMINI.md -->"
 
-ensure_obsidian_gitignore() {
+ensure_managed_gitignore_entries() {
   local repo_root="$1"
   local gitignore_path="$repo_root/.gitignore"
   local added_count=0
@@ -173,7 +175,7 @@ ensure_obsidian_gitignore() {
     ' "$file_path"
   }
 
-  for line in "${OBSIDIAN_GITIGNORE_LINES[@]}"; do
+  for line in "${MANAGED_GITIGNORE_LINES[@]}"; do
     if gitignore_has_line "$gitignore_path" "$line"; then
       continue
     fi
@@ -183,9 +185,9 @@ ensure_obsidian_gitignore() {
   done
 
   if [[ "$added_count" -gt 0 ]]; then
-    echo "Updated: .gitignore (added $added_count Obsidian ignore entries)"
+    echo "Updated: .gitignore (added $added_count managed ignore entries)"
   else
-    echo "Unchanged: .gitignore (Obsidian ignore entries already present)"
+    echo "Unchanged: .gitignore (managed ignore entries already present)"
   fi
 }
 
@@ -401,6 +403,6 @@ process_root_policy_file "GEMINI.md" "$project_dir/GEMINI.md" "$ROOT_GEMINI_MARK
 seed_root_file_if_missing "$root_scaffold_dir/.github/pull_request_template.md" "$canonical_repo_path/.github/pull_request_template.md"
 seed_root_file_if_missing "$root_scaffold_dir/docs/design.md" "$canonical_repo_path/docs/design.md"
 
-ensure_obsidian_gitignore "$canonical_repo_path"
+ensure_managed_gitignore_entries "$canonical_repo_path"
 
 echo "Created project notes at: $project_dir"

--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -31,7 +31,7 @@ expand_path() {
   esac
 }
 
-OBSIDIAN_GITIGNORE_LINES=(
+MANAGED_GITIGNORE_LINES=(
   "# Obsidian -- machine-specific & volatile files (ignore these)"
   ".obsidian/workspace.json"
   ".obsidian/app.json"
@@ -41,6 +41,8 @@ OBSIDIAN_GITIGNORE_LINES=(
   ".obsidian/backup/"
   "# Plugin data (can contain API keys or large caches)"
   ".obsidian/plugins/*/data.json"
+  "# Agent Vault -- local sync and migration backups (ignore these)"
+  "/agent-vault/context/updates/"
 )
 
 ROOT_AGENTS_MARKER="<!-- agent-vault-managed: root-wrapper; file=AGENTS.md -->"
@@ -363,7 +365,7 @@ sync_root_wrapper_if_managed() {
   skipped=$((skipped + 1))
 }
 
-ensure_obsidian_gitignore() {
+ensure_managed_gitignore_entries() {
   local repo_root="$1"
   local gitignore_path="$repo_root/.gitignore"
   local -a missing_lines=()
@@ -375,7 +377,7 @@ ensure_obsidian_gitignore() {
     existed="true"
   fi
 
-  for line in "${OBSIDIAN_GITIGNORE_LINES[@]}"; do
+  for line in "${MANAGED_GITIGNORE_LINES[@]}"; do
     if [[ -e "$gitignore_path" ]] && gitignore_has_line "$gitignore_path" "$line"; then
       continue
     fi
@@ -384,7 +386,7 @@ ensure_obsidian_gitignore() {
   done
 
   if [[ ${#missing_lines[@]} -eq 0 ]]; then
-    echo "Unchanged: .gitignore (Obsidian ignore entries present)"
+    echo "Unchanged: .gitignore (managed ignore entries present)"
     unchanged=$((unchanged + 1))
     return
   fi
@@ -395,7 +397,7 @@ ensure_obsidian_gitignore() {
       updated=$((updated + 1))
       backed_up=$((backed_up + 1))
     else
-      echo "Create: .gitignore (add ${#missing_lines[@]} Obsidian ignore entries)"
+      echo "Create: .gitignore (add ${#missing_lines[@]} managed ignore entries)"
       created=$((created + 1))
     fi
     return
@@ -415,10 +417,10 @@ ensure_obsidian_gitignore() {
   done
 
   if [[ "$existed" == "true" ]]; then
-    echo "Updated: .gitignore (added ${#missing_lines[@]} Obsidian ignore entries)"
+    echo "Updated: .gitignore (added ${#missing_lines[@]} managed ignore entries)"
     updated=$((updated + 1))
   else
-    echo "Created: .gitignore (added ${#missing_lines[@]} Obsidian ignore entries)"
+    echo "Created: .gitignore (added ${#missing_lines[@]} managed ignore entries)"
     created=$((created + 1))
   fi
 }
@@ -442,7 +444,7 @@ seed_if_missing "$vault_scaffold_dir/lessons.md" "$project_dir/lessons.md"
 seed_if_missing "$vault_scaffold_dir/daily/README.md" "$project_dir/daily/README.md"
 sync_template_files "$vault_scaffold_dir/Templates" "$project_dir/Templates"
 
-ensure_obsidian_gitignore "$canonical_repo_path"
+ensure_managed_gitignore_entries "$canonical_repo_path"
 
 echo
 echo "Summary:"


### PR DESCRIPTION
## Summary
- add `/agent-vault/context/updates/` to the managed root `.gitignore` entries
- broaden the helper naming from Obsidian-only ignore entries to managed local-only ignore entries
- document the backup ignore path in the template README

## Validation
- `bash scripts/check-policy-mirrors.sh`
- `bash -n scripts/new-project.sh scripts/update-project.sh scripts/check-policy-mirrors.sh`
- `git diff --check`
- temp-repo bootstrap test confirming fresh repos get `/agent-vault/context/updates/` in `.gitignore`
- temp-repo update test confirming existing repos get exactly one new ignore line on sync