### PR TITLE
Clarify attribution for standalone PR review comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,11 @@ Example:
 > 🤖 **Review by Claude Opus 4.6** · via Claude Code
 ```
 
+**Standalone PR comments** that contain review feedback (for example, a pull request issue comment used instead of a formal review body) must begin with the same attribution line:
+```
+> 🤖 **Review by {Model Name}** · via {Client Tool}
+```
+
 **Inline review comments** on specific lines must begin with:
 ```
 🤖 `{Model Name}`
@@ -139,6 +144,7 @@ Example:
 Rules:
 - Use your actual model name and version (e.g., Claude Opus 4.6, Codex 5.3, Gemini 2.5 Pro).
 - Include the client tool when known (e.g., Claude Code, Codex CLI, Gemini CLI).
+- If you are leaving review feedback in a standalone PR conversation comment instead of a formal review, use the same `Review by ...` attribution header at the top of that comment.
 - Never present review feedback as if it is the human account owner's personal opinion.
 - If you are uncertain of your exact model version, use the best identifier you have (e.g., "Claude" or "Codex").
 

--- a/scaffold/agent-vault/review-policy.md
+++ b/scaffold/agent-vault/review-policy.md
@@ -101,6 +101,11 @@ Example:
 > 🤖 **Review by Claude Opus 4.6** · via Claude Code
 ```
 
+**Standalone PR comments** that contain review feedback (for example, a pull request issue comment used instead of a formal review body) must begin with the same attribution line:
+```
+> 🤖 **Review by {Model Name}** · via {Client Tool}
+```
+
 **Inline review comments** on specific lines must begin with:
 ```
 🤖 `{Model Name}`
@@ -115,6 +120,7 @@ Example:
 Rules:
 - Use your actual model name and version (e.g., Claude Opus 4.6, Codex 5.3, Gemini 2.5 Pro).
 - Include the client tool when known (e.g., Claude Code, Codex CLI, Gemini CLI).
+- If you are leaving review feedback in a standalone PR conversation comment instead of a formal review, use the same `Review by ...` attribution header at the top of that comment.
 - Never present review feedback as if it is the human account owner's personal opinion.
 - If you are uncertain of your exact model version, use the best identifier you have (e.g., "Claude" or "Codex").
 

--- a/scaffold/root/AGENTS.md
+++ b/scaffold/root/AGENTS.md
@@ -121,6 +121,11 @@ Example:
 > 🤖 **Review by Claude Opus 4.6** · via Claude Code
 ```
 
+**Standalone PR comments** that contain review feedback (for example, a pull request issue comment used instead of a formal review body) must begin with the same attribution line:
+```
+> 🤖 **Review by {Model Name}** · via {Client Tool}
+```
+
 **Inline review comments** on specific lines must begin with:
 ```
 🤖 `{Model Name}`
@@ -135,6 +140,7 @@ Example:
 Rules:
 - Use your actual model name and version (e.g., Claude Opus 4.6, Codex 5.3, Gemini 2.5 Pro).
 - Include the client tool when known (e.g., Claude Code, Codex CLI, Gemini CLI).
+- If you are leaving review feedback in a standalone PR conversation comment instead of a formal review, use the same `Review by ...` attribution header at the top of that comment.
 - Never present review feedback as if it is the human account owner's personal opinion.
 - If you are uncertain of your exact model version, use the best identifier you have (e.g., "Claude" or "Codex").
 


### PR DESCRIPTION
## Summary
Clarify the review policy so standalone PR conversation comments that contain review feedback must use the same attribution header as a formal review summary.

## Files Changed
- `scaffold/agent-vault/review-policy.md`
  - Add explicit guidance that standalone PR feedback comments must begin with `> 🤖 **Review by {Model Name}** · via {Client Tool}`.
- `AGENTS.md`
  - Mirror the same review-policy clarification for Codex compatibility.
- `scaffold/root/AGENTS.md`
  - Mirror the same review-policy clarification for generated project root wrappers.

## Validation
- `bash scripts/check-policy-mirrors.sh` — passed
- `git diff --check` — passed

## Risks / Rollback
- Low risk: wording-only policy clarification.
- Rollback is straightforward: revert this commit if a different attribution policy is preferred.

## Docs
Documentation is consistent - design.md and README.md were checked and need no changes.