### PR TITLE
Fix Bash 3.2 managed .gitignore no-op warnings

### DIFF
--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -198,7 +198,9 @@ collect_missing_managed_gitignore_lines() {
     missing_lines+=("${missing_block_lines[@]}")
   done
 
-  printf '%s\n' "${missing_lines[@]}"
+  if [[ "${#missing_lines[@]}" -gt 0 ]]; then
+    printf '%s\n' "${missing_lines[@]}"
+  fi
 }
 
 ensure_managed_gitignore_entries() {

--- a/scripts/test-gitignore-management.sh
+++ b/scripts/test-gitignore-management.sh
@@ -12,6 +12,16 @@ cleanup() {
 
 trap cleanup EXIT
 
+assert_output_not_contains() {
+  local output="$1"
+  local unexpected_text="$2"
+
+  if [[ "$output" == *"$unexpected_text"* ]]; then
+    echo "Unexpected text found in command output: $unexpected_text" >&2
+    exit 1
+  fi
+}
+
 assert_has_line() {
   local file_path="$1"
   local expected_line="$2"
@@ -107,6 +117,24 @@ write_partial_obsidian_gitignore() {
 EOF
 }
 
+write_managed_gitignore() {
+  local repo_path="$1"
+
+  cat <<'EOF' > "$repo_path/.gitignore"
+# Obsidian -- machine-specific & volatile files (ignore these)
+.obsidian/workspace.json
+.obsidian/app.json
+.obsidian/appearance.json
+.obsidian/workspace-mobile.json
+.obsidian/cache/
+.obsidian/backup/
+# Plugin data (can contain API keys or large caches)
+.obsidian/plugins/*/data.json
+# Agent Vault -- local sync and migration backups (ignore these)
+/agent-vault/context/updates/
+EOF
+}
+
 assert_no_dangling_comment_append() {
   local file_path="$1"
 
@@ -140,6 +168,14 @@ write_partial_obsidian_gitignore "$new_project_partial_repo"
 "$repo_root/scripts/new-project.sh" "gitignore-test" "$new_project_partial_repo" >/dev/null
 assert_grouped_partial_block_insert "$new_project_partial_repo/.gitignore"
 
+new_project_managed_repo="$tmp_root/new-project-managed-patterns"
+init_repo "$new_project_managed_repo"
+write_managed_gitignore "$new_project_managed_repo"
+new_project_output="$("$repo_root/scripts/new-project.sh" "gitignore-test" "$new_project_managed_repo" 2>&1)"
+assert_output_not_contains "$new_project_output" "unbound variable"
+assert_output_not_contains "$new_project_output" "missing_lines[@]"
+assert_has_line "$new_project_managed_repo/.gitignore" "# Agent Vault -- local sync and migration backups (ignore these)"
+
 update_project_repo="$tmp_root/update-project-existing-patterns"
 init_repo "$update_project_repo"
 "$repo_root/scripts/new-project.sh" "gitignore-test" "$update_project_repo" >/dev/null
@@ -153,5 +189,14 @@ init_repo "$update_project_partial_repo"
 write_partial_obsidian_gitignore "$update_project_partial_repo"
 "$repo_root/scripts/update-project.sh" "$update_project_partial_repo" >/dev/null
 assert_grouped_partial_block_insert "$update_project_partial_repo/.gitignore"
+
+update_project_managed_repo="$tmp_root/update-project-managed-patterns"
+init_repo "$update_project_managed_repo"
+"$repo_root/scripts/new-project.sh" "gitignore-test" "$update_project_managed_repo" >/dev/null
+write_managed_gitignore "$update_project_managed_repo"
+update_project_output="$("$repo_root/scripts/update-project.sh" "$update_project_managed_repo" --dry-run --sync-templates 2>&1)"
+assert_output_not_contains "$update_project_output" "unbound variable"
+assert_output_not_contains "$update_project_output" "missing_lines[@]"
+assert_has_line "$update_project_managed_repo/.gitignore" "# Agent Vault -- local sync and migration backups (ignore these)"
 
 echo "gitignore management regression checks passed."

--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -263,7 +263,9 @@ collect_missing_managed_gitignore_lines() {
     missing_lines+=("${missing_block_lines[@]}")
   done
 
-  printf '%s\n' "${missing_lines[@]}"
+  if [[ "${#missing_lines[@]}" -gt 0 ]]; then
+    printf '%s\n' "${missing_lines[@]}"
+  fi
 }
 
 is_managed_root_wrapper() {


### PR DESCRIPTION
## Summary
- Fix the Bash 3.2 empty-array expansion in `collect_missing_managed_gitignore_lines()` so fully managed `.gitignore` files no longer emit `unbound variable` warnings on no-op paths.
- Apply the same guard in both `scripts/update-project.sh` and the duplicated helper in `scripts/new-project.sh` to keep behavior aligned.
- Add regression coverage for fully managed `.gitignore` inputs in both bootstrap and dry-run update flows.
- Closes #35.

## Files / Areas Changed
- `scripts/update-project.sh`: guard the empty `missing_lines` array before `printf` in the no-op path.
- `scripts/new-project.sh`: apply the same guard in the duplicated helper used during project bootstrap.
- `scripts/test-gitignore-management.sh`: add fully managed `.gitignore` fixtures plus assertions that command output does not contain the Bash 3.2 warning.

## Validation
- `bash scripts/test-gitignore-management.sh`
- `bash -n scripts/update-project.sh scripts/new-project.sh scripts/test-gitignore-management.sh`
- Manual repro check: `bash scripts/new-project.sh easy-test <tmp-repo>` with a fully managed `.gitignore` no longer emits `missing_lines[@]: unbound variable`.
- Manual repro check: `bash scripts/update-project.sh <tmp-repo> --dry-run --sync-templates` with a fully managed `.gitignore` no longer emits `missing_lines[@]: unbound variable`.

## Risks / Rollback
- Risk is low: the logic change only affects the empty-output path when no managed `.gitignore` lines are missing.
- Rollback is straightforward: revert commit `9ae5d25`.

## Docs Consistency
Documentation is consistent - design.md and README.md were checked and need no changes.