### PR TITLE
Consolidate new-project scaffold validation checks

### DIFF
--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -311,47 +311,31 @@ if [[ ! -d "$root_scaffold_dir" ]]; then
   exit 1
 fi
 
-for root_file in AGENTS.md CLAUDE.md GEMINI.md; do
-  if [[ ! -f "$root_scaffold_dir/$root_file" ]]; then
-    echo "Error: missing root scaffold file: $root_scaffold_dir/$root_file"
+for required in \
+  "$root_scaffold_dir/AGENTS.md" \
+  "$root_scaffold_dir/CLAUDE.md" \
+  "$root_scaffold_dir/GEMINI.md" \
+  "$root_scaffold_dir/.github/pull_request_template.md" \
+  "$root_scaffold_dir/docs/design.md"
+do
+  if [[ ! -f "$required" ]]; then
+    echo "Error: missing root scaffold file: $required"
     exit 1
   fi
 done
 
-if [[ ! -f "$root_scaffold_dir/.github/pull_request_template.md" ]]; then
-  echo "Error: missing root scaffold file: $root_scaffold_dir/.github/pull_request_template.md"
-  exit 1
-fi
-
-if [[ ! -f "$root_scaffold_dir/docs/design.md" ]]; then
-  echo "Error: missing root scaffold file: $root_scaffold_dir/docs/design.md"
-  exit 1
-fi
-
-if [[ ! -f "$scaffold_dir/handoff.md" ]]; then
-  echo "Error: missing scaffold file: $scaffold_dir/handoff.md"
-  exit 1
-fi
-
-if [[ ! -f "$scaffold_dir/design-log/README.md" ]]; then
-  echo "Error: missing scaffold file: $scaffold_dir/design-log/README.md"
-  exit 1
-fi
-
-if [[ ! -f "$scaffold_dir/context/handoffs/README.md" ]]; then
-  echo "Error: missing scaffold file: $scaffold_dir/context/handoffs/README.md"
-  exit 1
-fi
-
-if [[ ! -f "$scaffold_dir/decisions/README.md" ]]; then
-  echo "Error: missing scaffold file: $scaffold_dir/decisions/README.md"
-  exit 1
-fi
-
-if [[ ! -f "$scaffold_dir/daily/README.md" ]]; then
-  echo "Error: missing scaffold file: $scaffold_dir/daily/README.md"
-  exit 1
-fi
+for required in \
+  "$scaffold_dir/handoff.md" \
+  "$scaffold_dir/design-log/README.md" \
+  "$scaffold_dir/context/handoffs/README.md" \
+  "$scaffold_dir/decisions/README.md" \
+  "$scaffold_dir/daily/README.md"
+do
+  if [[ ! -f "$required" ]]; then
+    echo "Error: missing scaffold file: $required"
+    exit 1
+  fi
+done
 
 cp -R "$scaffold_dir" "$project_dir"
 


### PR DESCRIPTION
## Summary
- Replace the repetitive scaffold file existence checks in `scripts/new-project.sh` with grouped `for required in ...` loops.
- Keep the existing `missing root scaffold file` and `missing scaffold file` error messages intact while aligning the structure more closely with `scripts/update-project.sh`.
- Reduce drift between the bootstrap and update validation sections without changing scaffold ownership or bootstrap behavior.
- Closes #23.

## Files / Areas Changed
- `scripts/new-project.sh`: refactor the root scaffold and scaffold file validation blocks into loop-based checks.

## Validation
- `bash -n scripts/new-project.sh scripts/update-project.sh scripts/test-gitignore-management.sh`
- `bash scripts/test-gitignore-management.sh`
- Smoke check: run `bash scripts/new-project.sh smoke-test <tmp-repo>` in a temporary repo, then `bash scripts/update-project.sh <tmp-repo> --dry-run`

## Risks / Rollback
- Risk is low: this is a structural refactor of startup validation only, with the same required file set and error strings preserved.
- Rollback is straightforward: revert commit `02ae268`.

## Docs Consistency
Documentation is consistent - design.md and README.md were checked and need no changes.