### PR TITLE
docs: clarify project template seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,6 @@ It also creates project-root files when missing:
 - `<repo-path>/GEMINI.md` -> imports `agent-vault/GEMINI.md` and `agent-vault/review-policy.md`
 - `<repo-path>/docs/design.md` -> starter architecture/design document with embedded Mermaid diagrams
 - `<repo-path>/.github/pull_request_template.md` -> standardized agent PR body template
-- Bootstrap behavior: `new-project.sh` hydrates project metadata placeholders (`repo_reference`, active branch, dates) in the baseline `agent-vault/` docs, seeds non-empty baseline content in required core docs (`agent-vault/README.md`, `plan.md`, `coding-standards.md`, `context-log.md`, `project-context.md`, and `project-commands.md`), and copies scaffold helper docs such as `agent-vault/design-log/README.md` plus `docs/design.md`.
+- Bootstrap behavior: `new-project.sh` hydrates project metadata placeholders (`repo_reference`, active branch, dates) in the baseline `agent-vault/` docs, seeds non-empty baseline content in `agent-vault/README.md`, `plan.md`, `coding-standards.md`, and `context-log.md`, copies structured starter templates for `project-context.md` and `project-commands.md`, and copies scaffold helper docs such as `agent-vault/design-log/README.md` plus `docs/design.md`.
 
 If root files already exist, the script leaves them unchanged unless `--migrate-existing-root-md` is provided.


### PR DESCRIPTION
> 🤖 Prepared by Codex · via Codex CLI

## Summary
- Problem: the root README said `new-project.sh` seeds non-empty baseline content in `project-context.md` and `project-commands.md`, but those scaffold files are currently starter templates that still need project-specific content filled in.
- Approach: tighten the README wording so it distinguishes between docs that are hydrated with non-empty baseline content and the two structured starter-template files.
- Outcome: the README now matches the actual behavior of `new-project.sh` and the current scaffold.

## Changes
- `README.md`: clarified that `new-project.sh` seeds non-empty baseline content in `agent-vault/README.md`, `plan.md`, `coding-standards.md`, and `context-log.md`, while `project-context.md` and `project-commands.md` are copied as structured starter templates.

## Validation
- `git -C /Users/stephensheldon/workspaces/agent-vault diff --check`: passed.
- Manual check against `scaffold/agent-vault/project-context.md` and `scaffold/agent-vault/project-commands.md`: both remain placeholder templates, so the revised README wording is accurate.
- Not run: script/bootstrap tests, because this PR only updates README wording and does not change scaffold files or script behavior.

## Risks and Rollback
- Risk: none beyond ordinary documentation wording drift.
- Mitigation: wording now matches the actual scaffold files.
- Rollback: revert commit `9f8928e`.

## Docs Consistency
- `docs/design.md`: No impact. This PR is documentation-only in the root README.
- `README.md`: Updated to match current scaffold behavior.

## Follow-Ups
- [ ] None
