### PR TITLE
fix: Make hook activation failures visible in scaffold scripts

### DIFF
--- a/scripts/lib/tracked-hooks.sh
+++ b/scripts/lib/tracked-hooks.sh
@@ -7,7 +7,7 @@ configure_tracked_hooks_path() {
   local current_hooks_path=""
 
   if ! git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    return
+    return 1
   fi
 
   current_hooks_path="$(git -C "$repo_root" config --get core.hooksPath 2>/dev/null || true)"
@@ -17,17 +17,22 @@ configure_tracked_hooks_path() {
       echo "Dry run: would enable tracked metadata hook via core.hooksPath=$desired_hooks_path"
     else
       git -C "$repo_root" config --local core.hooksPath "$desired_hooks_path"
+      if [[ "$(git -C "$repo_root" config --get core.hooksPath 2>/dev/null)" != "$desired_hooks_path" ]]; then
+        echo "Warning: core.hooksPath was set but read-back does not match expected value '$desired_hooks_path'." >&2
+        return 1
+      fi
       echo "Enabled tracked metadata hook via core.hooksPath=$desired_hooks_path"
     fi
-    return
+    return 0
   fi
 
   if [[ "$current_hooks_path" == "$desired_hooks_path" ]]; then
     echo "Tracked metadata hook already enabled via core.hooksPath=$desired_hooks_path"
-    return
+    return 0
   fi
 
   echo "Notice: effective core.hooksPath already set to '$current_hooks_path'; left unchanged." >&2
   echo "To use the tracked agent-vault hook in this clone, run:" >&2
   echo "  git -C \"$repo_root\" config core.hooksPath $desired_hooks_path" >&2
+  return 1
 }

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -451,5 +451,11 @@ seed_root_file_if_missing "$root_scaffold_dir/.github/pull_request_template.md" 
 seed_root_file_if_missing "$root_scaffold_dir/docs/design.md" "$canonical_repo_path/docs/design.md"
 
 ensure_managed_gitignore_entries "$canonical_repo_path"
-configure_tracked_hooks_path "$canonical_repo_path"
+hook_rc=0
+configure_tracked_hooks_path "$canonical_repo_path" || hook_rc=$?
+if [[ "$hook_rc" -ne 0 ]]; then
+  echo "Warning: tracked metadata hook could not be activated automatically." >&2
+  echo "To enable it manually, run:" >&2
+  echo "  git -C \"$canonical_repo_path\" config core.hooksPath agent-vault/_assets/hooks" >&2
+fi
 echo "Created project notes at: $project_dir"

--- a/scripts/test-session-metadata-hook.sh
+++ b/scripts/test-session-metadata-hook.sh
@@ -215,4 +215,17 @@ if [[ "$(git -C "$success_rc_repo" config --local --get core.hooksPath)" != "age
   exit 1
 fi
 
+dryrun_rc_repo="$tmp_root/dryrun-returns-zero"
+init_repo "$dryrun_rc_repo"
+dryrun_rc=0
+dryrun_output="$(configure_tracked_hooks_path "$dryrun_rc_repo" "true")" || dryrun_rc=$?
+if [[ "$dryrun_rc" -ne 0 ]]; then
+  echo "Expected configure_tracked_hooks_path to return zero on dry-run activation." >&2
+  exit 1
+fi
+if git -C "$dryrun_rc_repo" config --local --get core.hooksPath >/dev/null 2>&1; then
+  echo "Expected core.hooksPath to remain unset after dry-run activation." >&2
+  exit 1
+fi
+
 echo "session metadata hook regression checks passed."

--- a/scripts/test-session-metadata-hook.sh
+++ b/scripts/test-session-metadata-hook.sh
@@ -189,4 +189,30 @@ assert_output_contains "$deletion_failure_output" "stage agent-vault/context-log
 assert_output_contains "$deletion_failure_output" "stage one note under agent-vault/daily/"
 assert_output_contains "$deletion_failure_output" "stage one note under agent-vault/design-log/"
 
+# shellcheck source=./lib/tracked-hooks.sh
+source "$script_dir/lib/tracked-hooks.sh"
+
+custom_rc_repo="$tmp_root/custom-hooks-returns-nonzero"
+init_repo "$custom_rc_repo"
+git -C "$custom_rc_repo" config --local core.hooksPath .githooks
+custom_rc=0
+configure_tracked_hooks_path "$custom_rc_repo" || custom_rc=$?
+if [[ "$custom_rc" -eq 0 ]]; then
+  echo "Expected configure_tracked_hooks_path to return non-zero when custom core.hooksPath is set." >&2
+  exit 1
+fi
+
+success_rc_repo="$tmp_root/activation-returns-zero"
+init_repo "$success_rc_repo"
+success_rc=0
+configure_tracked_hooks_path "$success_rc_repo" || success_rc=$?
+if [[ "$success_rc" -ne 0 ]]; then
+  echo "Expected configure_tracked_hooks_path to return zero on successful activation." >&2
+  exit 1
+fi
+if [[ "$(git -C "$success_rc_repo" config --local --get core.hooksPath)" != "agent-vault/_assets/hooks" ]]; then
+  echo "Expected core.hooksPath to be set after successful activation." >&2
+  exit 1
+fi
+
 echo "session metadata hook regression checks passed."

--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -520,10 +520,11 @@ echo "- updated: $updated"
 echo "- unchanged: $unchanged"
 echo "- skipped: $skipped"
 echo "- backups: $backed_up"
-if [[ "$hook_rc" -eq 0 && "$dry_run" == "true" ]]; then
-  echo "- hook: would enable"
-elif [[ "$hook_rc" -eq 0 ]]; then
+actual_hooks_path="$(git -C "$canonical_repo_path" config --get core.hooksPath 2>/dev/null || true)"
+if [[ "$actual_hooks_path" == "agent-vault/_assets/hooks" ]]; then
   echo "- hook: enabled"
+elif [[ "$hook_rc" -eq 0 && "$dry_run" == "true" ]]; then
+  echo "- hook: would enable"
 else
   echo "- hook: NOT active (see warning below)"
 fi

--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -520,7 +520,9 @@ echo "- updated: $updated"
 echo "- unchanged: $unchanged"
 echo "- skipped: $skipped"
 echo "- backups: $backed_up"
-if [[ "$hook_rc" -eq 0 ]]; then
+if [[ "$hook_rc" -eq 0 && "$dry_run" == "true" ]]; then
+  echo "- hook: would enable"
+elif [[ "$hook_rc" -eq 0 ]]; then
   echo "- hook: enabled"
 else
   echo "- hook: NOT active (see warning below)"

--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -510,6 +510,9 @@ sync_template_files "$vault_scaffold_dir/Templates" "$project_dir/Templates"
 
 ensure_managed_gitignore_entries "$canonical_repo_path"
 
+hook_rc=0
+configure_tracked_hooks_path "$canonical_repo_path" "$dry_run" || hook_rc=$?
+
 echo
 echo "Summary:"
 echo "- created: $created"
@@ -517,6 +520,11 @@ echo "- updated: $updated"
 echo "- unchanged: $unchanged"
 echo "- skipped: $skipped"
 echo "- backups: $backed_up"
+if [[ "$hook_rc" -eq 0 ]]; then
+  echo "- hook: enabled"
+else
+  echo "- hook: NOT active (see warning below)"
+fi
 
 if [[ "$dry_run" == "true" ]]; then
   echo "Dry run complete. No files were written."
@@ -524,4 +532,9 @@ elif [[ "$backed_up" -gt 0 ]]; then
   echo "Backups saved under: $backup_dir"
 fi
 
-configure_tracked_hooks_path "$canonical_repo_path" "$dry_run"
+if [[ "$hook_rc" -ne 0 ]]; then
+  echo
+  echo "Warning: tracked metadata hook could not be activated automatically." >&2
+  echo "To enable it manually, run:" >&2
+  echo "  git -C \"$canonical_repo_path\" config core.hooksPath agent-vault/_assets/hooks" >&2
+fi


### PR DESCRIPTION
## Summary

- `configure_tracked_hooks_path()` silently returned 0 even when it failed to activate the hook (e.g., custom `core.hooksPath` conflict or not-a-repo). Callers had no way to detect failure.
- `update-project.sh` printed the summary *before* calling hook activation, so the output gave no visibility into whether it succeeded.
- This caused CritterCam's PR #83 scaffold sync to silently skip hook activation, with the daily note and design-log incorrectly claiming it was enabled.

## Changes

### `scripts/lib/tracked-hooks.sh`
- Return 0 only on confirmed activation (set, already set, or dry-run).
- Return 1 on skip (not a repo, custom path conflict) or failure.
- Added read-back verification after `git config --local` to catch silent write failures.

### `scripts/update-project.sh`
- Moved `configure_tracked_hooks_path` call before the summary block.
- Captures return code and includes hook status in the summary output.
- On failure, prints a warning with the manual activation command.

### `scripts/new-project.sh`
- Captures return code from `configure_tracked_hooks_path`.
- Prints warning with manual command on failure.

### `scripts/test-session-metadata-hook.sh`
- Added test: custom `core.hooksPath` → `configure_tracked_hooks_path` returns non-zero.
- Added test: fresh activation → returns zero and sets the expected path.

## Validation
- `bash scripts/test-session-metadata-hook.sh` → all regression checks passed.

## Risks
- Callers that previously ignored the return code will now see a non-zero exit. Since both callers (`update-project.sh`, `new-project.sh`) run under `set -e`, the new explicit return-code capture prevents unexpected script termination.

Documentation is consistent — no design.md or README.md changes needed (shell scripts only).