### PR TITLE
Enforce context-log freshness in tracked metadata hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ When a managed file changes, the script backs up the previous version under:
 Generated projects auto-enable the tracked metadata gate in the clone where `new-project.sh` or `update-project.sh` runs, unless `core.hooksPath` is already set to something else. Additional clones can enable it with:
 - `git -C <repo-path> config core.hooksPath agent-vault/_assets/hooks`
 
+That tracked hook enforces the baseline session artifacts and validates staged `agent-vault/context-log.md` ordering/freshness so newer entries do not get appended below stale headers.
+
 Both scripts also ensure root `.gitignore` includes managed local-only ignore entries (added only when missing):
 - `.obsidian/workspace.json`
 - `.obsidian/app.json`

--- a/scaffold/agent-vault/Templates/Context Log.md
+++ b/scaffold/agent-vault/Templates/Context Log.md
@@ -8,6 +8,7 @@ last_updated:
 
 ## Usage Rules
 - Newest entry at top.
+- Entry headings must start with `YYYY-MM-DD HH:MM local - <agent> - <topic>`.
 - Keep entries short and concrete.
 - Reference files and PRs instead of pasting long diffs.
 - Pair each major update with a design-log entry.

--- a/scaffold/agent-vault/_assets/hooks/README.md
+++ b/scaffold/agent-vault/_assets/hooks/README.md
@@ -17,6 +17,10 @@ git config core.hooksPath agent-vault/_assets/hooks
     - `agent-vault/context-log.md`
     - one note under `agent-vault/daily/`
     - one note under `agent-vault/design-log/`
+  - Validates staged `agent-vault/context-log.md` content:
+    - entry headings must use `YYYY-MM-DD HH:MM local - <agent> - <topic>`
+    - entries must remain newest-first
+    - frontmatter and Current Snapshot `Last updated` must match the top entry date
   - This is a baseline gate only. Conditional artifacts such as `open-questions.md`, decision records, handoff notes, and `lessons.md` still depend on the actual session outcome.
 
 ## Intentional Bypass

--- a/scaffold/agent-vault/_assets/hooks/pre-commit
+++ b/scaffold/agent-vault/_assets/hooks/pre-commit
@@ -46,6 +46,143 @@ is_runtime_note_file() {
   esac
 }
 
+extract_context_log_frontmatter_value() {
+  local file_path="$1"
+  local field_name="$2"
+
+  awk -v field_name="$field_name" '
+    BEGIN {
+      frontmatter_markers = 0
+    }
+    /^---$/ {
+      frontmatter_markers += 1
+      next
+    }
+    frontmatter_markers == 1 && index($0, field_name ":") == 1 {
+      value = substr($0, length(field_name) + 2)
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      print value
+      exit
+    }
+    frontmatter_markers >= 2 {
+      exit
+    }
+  ' "$file_path"
+}
+
+extract_context_log_snapshot_last_updated() {
+  local file_path="$1"
+
+  awk '
+    /^## Current Snapshot$/ {
+      in_snapshot = 1
+      next
+    }
+    in_snapshot && /^## / {
+      exit
+    }
+    in_snapshot && /^- Last updated:/ {
+      value = $0
+      sub(/^- Last updated:[[:space:]]*/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      print value
+      exit
+    }
+  ' "$file_path"
+}
+
+collect_context_log_entry_timestamps() {
+  local file_path="$1"
+
+  awk '
+    /^## Entries$/ {
+      in_entries = 1
+      next
+    }
+    in_entries && /^## / {
+      exit
+    }
+    in_entries && /^### / {
+      if (match($0, /^### ([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9]) local - /)) {
+        timestamp = $0
+        sub(/^### /, "", timestamp)
+        sub(/ local - .*$/, "", timestamp)
+        print timestamp
+        next
+      }
+
+      printf "__INVALID__\t%s\n", $0
+    }
+  ' "$file_path"
+}
+
+validate_staged_context_log() {
+  local file_path="$1"
+  local tmp_file=""
+  local first_timestamp=""
+  local first_date=""
+  local last_updated=""
+  local snapshot_last_updated=""
+  local previous_timestamp=""
+  local current_timestamp=""
+  local current_entry_line=""
+  local has_entries="false"
+  local -a errors=()
+
+  tmp_file="$(mktemp "${TMPDIR:-/tmp}/agent-vault-context-log.XXXXXX")"
+  git show ":$file_path" >"$tmp_file" 2>/dev/null || {
+    rm -f "$tmp_file"
+    echo "Unable to read staged $file_path for validation."
+    return 1
+  }
+
+  while IFS= read -r current_entry_line; do
+    [[ -n "$current_entry_line" ]] || continue
+    has_entries="true"
+
+    if [[ "$current_entry_line" == __INVALID__* ]]; then
+      errors+=("$file_path entry headings must start with \`YYYY-MM-DD HH:MM local - <agent> - <topic>\`; found: ${current_entry_line#*$'\t'}")
+      continue
+    fi
+
+    current_timestamp="$current_entry_line"
+
+    if [[ -z "$first_timestamp" ]]; then
+      first_timestamp="$current_timestamp"
+      first_date="${current_timestamp%% *}"
+    elif [[ "$current_timestamp" > "$previous_timestamp" ]]; then
+      errors+=("$file_path must keep entries newest-first; found newer entry \`$current_timestamp\` below older entry \`$previous_timestamp\`.")
+    fi
+
+    previous_timestamp="$current_timestamp"
+  done < <(collect_context_log_entry_timestamps "$tmp_file")
+
+  if [[ "$has_entries" != "true" ]]; then
+    errors+=("$file_path must include at least one entry under \`## Entries\`.")
+  fi
+
+  last_updated="$(extract_context_log_frontmatter_value "$tmp_file" "last_updated")"
+  snapshot_last_updated="$(extract_context_log_snapshot_last_updated "$tmp_file")"
+
+  if [[ -n "$first_date" && "$last_updated" != "$first_date" ]]; then
+    errors+=("$file_path frontmatter \`last_updated\` must match the top entry date \`$first_date\`; found \`${last_updated:-<empty>}\`.")
+  fi
+
+  if [[ -n "$first_date" && "$snapshot_last_updated" != "$first_date" ]]; then
+    errors+=("$file_path Current Snapshot \`Last updated\` must match the top entry date \`$first_date\`; found \`${snapshot_last_updated:-<empty>}\`.")
+  fi
+
+  rm -f "$tmp_file"
+
+  if [[ "${#errors[@]}" -eq 0 ]]; then
+    return 0
+  fi
+
+  printf '%s\n' "${errors[@]}"
+  return 1
+}
+
 all_staged_files=()
 while IFS= read -r file_path; do
   [[ -n "$file_path" ]] || continue
@@ -108,7 +245,24 @@ if [[ "$has_design_log" != "true" ]]; then
 fi
 
 if [[ "${#missing_items[@]}" -eq 0 ]]; then
-  exit 0
+  context_log_validation_failed="false"
+  context_log_validation_output=""
+
+  if [[ "$has_context_log" == "true" ]]; then
+    context_log_validation_output="$(validate_staged_context_log "agent-vault/context-log.md" 2>&1)" || context_log_validation_failed="true"
+  fi
+
+  if [[ "$context_log_validation_failed" != "true" ]]; then
+    exit 0
+  fi
+
+  echo "agent-vault metadata gate failed." >&2
+  echo "Context log validation failed:" >&2
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    echo "- $line" >&2
+  done <<<"$context_log_validation_output"
+  exit 1
 fi
 
 echo "agent-vault metadata gate failed." >&2

--- a/scaffold/agent-vault/_assets/hooks/pre-commit
+++ b/scaffold/agent-vault/_assets/hooks/pre-commit
@@ -131,8 +131,8 @@ validate_staged_context_log() {
   local -a errors=()
 
   tmp_file="$(mktemp "${TMPDIR:-/tmp}/agent-vault-context-log.XXXXXX")"
+  trap 'rm -f "$tmp_file"; trap - RETURN' RETURN
   git show ":$file_path" >"$tmp_file" 2>/dev/null || {
-    rm -f "$tmp_file"
     echo "Unable to read staged $file_path for validation."
     return 1
   }
@@ -173,6 +173,7 @@ validate_staged_context_log() {
     errors+=("$file_path Current Snapshot \`Last updated\` must match the top entry date \`$first_date\`; found \`${snapshot_last_updated:-<empty>}\`.")
   fi
 
+  trap - RETURN
   rm -f "$tmp_file"
 
   if [[ "${#errors[@]}" -eq 0 ]]; then
@@ -193,6 +194,37 @@ if [[ "${#all_staged_files[@]}" -eq 0 ]]; then
   exit 0
 fi
 
+non_deleted_staged_files=()
+while IFS= read -r file_path; do
+  [[ -n "$file_path" ]] || continue
+  non_deleted_staged_files+=("$file_path")
+done < <(git diff --cached --name-only --diff-filter=ACMRTUXB)
+
+has_context_log="false"
+for file_path in "${non_deleted_staged_files[@]}"; do
+  if [[ "$file_path" == "agent-vault/context-log.md" ]]; then
+    has_context_log="true"
+    break
+  fi
+done
+
+context_log_validation_failed="false"
+context_log_validation_output=""
+
+if [[ "$has_context_log" == "true" ]]; then
+  context_log_validation_output="$(validate_staged_context_log "agent-vault/context-log.md" 2>&1)" || context_log_validation_failed="true"
+fi
+
+if [[ "$context_log_validation_failed" == "true" ]]; then
+  echo "agent-vault metadata gate failed." >&2
+  echo "Context log validation failed:" >&2
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    echo "- $line" >&2
+  done <<<"$context_log_validation_output"
+  exit 1
+fi
+
 requires_metadata_gate="false"
 for file_path in "${all_staged_files[@]}"; do
   if ! is_runtime_note_file "$file_path"; then
@@ -205,20 +237,12 @@ if [[ "$requires_metadata_gate" != "true" ]]; then
   exit 0
 fi
 
-has_context_log="false"
 has_daily_note="false"
 has_design_log="false"
-
-non_deleted_staged_files=()
-while IFS= read -r file_path; do
-  [[ -n "$file_path" ]] || continue
-  non_deleted_staged_files+=("$file_path")
-done < <(git diff --cached --name-only --diff-filter=ACMRTUXB)
 
 for file_path in "${non_deleted_staged_files[@]}"; do
   case "$file_path" in
     agent-vault/context-log.md)
-      has_context_log="true"
       ;;
     agent-vault/daily/*.md)
       if [[ "$file_path" != "agent-vault/daily/README.md" ]]; then
@@ -245,24 +269,7 @@ if [[ "$has_design_log" != "true" ]]; then
 fi
 
 if [[ "${#missing_items[@]}" -eq 0 ]]; then
-  context_log_validation_failed="false"
-  context_log_validation_output=""
-
-  if [[ "$has_context_log" == "true" ]]; then
-    context_log_validation_output="$(validate_staged_context_log "agent-vault/context-log.md" 2>&1)" || context_log_validation_failed="true"
-  fi
-
-  if [[ "$context_log_validation_failed" != "true" ]]; then
-    exit 0
-  fi
-
-  echo "agent-vault metadata gate failed." >&2
-  echo "Context log validation failed:" >&2
-  while IFS= read -r line; do
-    [[ -n "$line" ]] || continue
-    echo "- $line" >&2
-  done <<<"$context_log_validation_output"
-  exit 1
+  exit 0
 fi
 
 echo "agent-vault metadata gate failed." >&2

--- a/scaffold/agent-vault/context-log.md
+++ b/scaffold/agent-vault/context-log.md
@@ -8,6 +8,7 @@ last_updated: __DATE__
 
 ## Usage Rules
 - Newest entry at top.
+- Entry headings must start with `YYYY-MM-DD HH:MM local - <agent> - <topic>`.
 - Keep entries short and concrete.
 - Reference files and PRs instead of pasting long diffs.
 - Pair each major update with a design-log entry.

--- a/scripts/test-session-metadata-hook.sh
+++ b/scripts/test-session-metadata-hook.sh
@@ -70,6 +70,21 @@ run_hook_expect_success() {
   (cd "$repo_path" && agent-vault/_assets/hooks/pre-commit)
 }
 
+replace_first_match() {
+  local file_path="$1"
+  local search_text="$2"
+  local replacement_text="$3"
+
+  perl -0pi -e 's/\Q'"$search_text"'\E/'"$replacement_text"'/' "$file_path"
+}
+
+replace_first_context_log_timestamp() {
+  local file_path="$1"
+  local replacement_timestamp="$2"
+
+  perl -0pi -e 's/^### [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2} local - /### '"$replacement_timestamp"' local - /m' "$file_path"
+}
+
 hook_repo="$tmp_root/hook-enforcement"
 init_repo "$hook_repo"
 "$repo_root/scripts/new-project.sh" "hook-test" "$hook_repo" >/dev/null
@@ -188,6 +203,78 @@ deletion_failure_output="$(run_hook_expect_failure "$deletion_repo")"
 assert_output_contains "$deletion_failure_output" "stage agent-vault/context-log.md"
 assert_output_contains "$deletion_failure_output" "stage one note under agent-vault/daily/"
 assert_output_contains "$deletion_failure_output" "stage one note under agent-vault/design-log/"
+
+ordering_repo="$tmp_root/context-log-ordering"
+init_repo "$ordering_repo"
+"$repo_root/scripts/new-project.sh" "hook-test" "$ordering_repo" >/dev/null
+replace_first_context_log_timestamp "$ordering_repo/agent-vault/context-log.md" "$today 09:00"
+cat <<EOF >> "$ordering_repo/agent-vault/context-log.md"
+
+### $today 10:00 local - test-agent - appended newer entry below older one
+#### Goal
+Exercise ordering validation.
+
+#### State
+- Added a newer entry in the wrong position.
+
+#### Decisions
+- None.
+
+#### Open Questions
+- None.
+
+#### Next Prompt
+"Fix context log ordering."
+
+#### References
+- agent-vault/context-log.md
+EOF
+cat <<EOF > "$ordering_repo/agent-vault/daily/$today.md"
+# Daily Note
+
+- Seed ordering validation fixture.
+EOF
+cat <<EOF > "$ordering_repo/agent-vault/design-log/$today-0300-context-log-ordering.md"
+# Design Log
+
+- Seed ordering validation fixture.
+EOF
+mkdir -p "$ordering_repo/src"
+printf 'print("ordering")\n' > "$ordering_repo/src/app.py"
+git -C "$ordering_repo" add \
+  src/app.py \
+  agent-vault/context-log.md \
+  "agent-vault/daily/$today.md" \
+  "agent-vault/design-log/$today-0300-context-log-ordering.md"
+ordering_failure_output="$(run_hook_expect_failure "$ordering_repo")"
+assert_output_contains "$ordering_failure_output" "Context log validation failed:"
+assert_output_contains "$ordering_failure_output" 'must keep entries newest-first'
+
+freshness_repo="$tmp_root/context-log-freshness"
+init_repo "$freshness_repo"
+"$repo_root/scripts/new-project.sh" "hook-test" "$freshness_repo" >/dev/null
+replace_first_match "$freshness_repo/agent-vault/context-log.md" "last_updated: $today" "last_updated: 2000-01-01"
+replace_first_match "$freshness_repo/agent-vault/context-log.md" "- Last updated: $today" "- Last updated: 2000-01-01"
+cat <<EOF > "$freshness_repo/agent-vault/daily/$today.md"
+# Daily Note
+
+- Seed freshness validation fixture.
+EOF
+cat <<EOF > "$freshness_repo/agent-vault/design-log/$today-0400-context-log-freshness.md"
+# Design Log
+
+- Seed freshness validation fixture.
+EOF
+mkdir -p "$freshness_repo/src"
+printf 'print("freshness")\n' > "$freshness_repo/src/app.py"
+git -C "$freshness_repo" add \
+  src/app.py \
+  agent-vault/context-log.md \
+  "agent-vault/daily/$today.md" \
+  "agent-vault/design-log/$today-0400-context-log-freshness.md"
+freshness_failure_output="$(run_hook_expect_failure "$freshness_repo")"
+assert_output_contains "$freshness_failure_output" 'frontmatter `last_updated` must match the top entry date'
+assert_output_contains "$freshness_failure_output" 'Current Snapshot `Last updated` must match the top entry date'
 
 # shellcheck source=./lib/tracked-hooks.sh
 source "$script_dir/lib/tracked-hooks.sh"

--- a/scripts/test-session-metadata-hook.sh
+++ b/scripts/test-session-metadata-hook.sh
@@ -85,6 +85,19 @@ replace_first_context_log_timestamp() {
   perl -0pi -e 's/^### [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2} local - /### '"$replacement_timestamp"' local - /m' "$file_path"
 }
 
+replace_first_context_log_heading() {
+  local file_path="$1"
+  local replacement_heading="$2"
+
+  perl -0pi -e 's/^### [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2} local - .*$/### '"$replacement_heading"'/m' "$file_path"
+}
+
+clear_context_log_entries() {
+  local file_path="$1"
+
+  perl -0pi -e 's/^## Entries\s*\n.*\z/## Entries\n/mgs' "$file_path"
+}
+
 hook_repo="$tmp_root/hook-enforcement"
 init_repo "$hook_repo"
 "$repo_root/scripts/new-project.sh" "hook-test" "$hook_repo" >/dev/null
@@ -131,6 +144,17 @@ init_repo "$metadata_only_repo"
 printf '\nMetadata-only change.\n' >> "$metadata_only_repo/agent-vault/context-log.md"
 git -C "$metadata_only_repo" add agent-vault/context-log.md
 run_hook_expect_success "$metadata_only_repo"
+
+metadata_only_invalid_repo="$tmp_root/metadata-only-invalid"
+init_repo "$metadata_only_invalid_repo"
+"$repo_root/scripts/new-project.sh" "hook-test" "$metadata_only_invalid_repo" >/dev/null
+replace_first_match "$metadata_only_invalid_repo/agent-vault/context-log.md" "last_updated: $today" "last_updated: 2000-01-01"
+replace_first_match "$metadata_only_invalid_repo/agent-vault/context-log.md" "- Last updated: $today" "- Last updated: 2000-01-01"
+git -C "$metadata_only_invalid_repo" add agent-vault/context-log.md
+metadata_only_invalid_output="$(run_hook_expect_failure "$metadata_only_invalid_repo")"
+assert_output_contains "$metadata_only_invalid_output" "Context log validation failed:"
+assert_output_contains "$metadata_only_invalid_output" 'frontmatter `last_updated` must match the top entry date'
+assert_output_contains "$metadata_only_invalid_output" 'Current Snapshot `Last updated` must match the top entry date'
 
 update_repo="$tmp_root/update-project-hook-seed"
 init_repo "$update_repo"
@@ -275,6 +299,22 @@ git -C "$freshness_repo" add \
 freshness_failure_output="$(run_hook_expect_failure "$freshness_repo")"
 assert_output_contains "$freshness_failure_output" 'frontmatter `last_updated` must match the top entry date'
 assert_output_contains "$freshness_failure_output" 'Current Snapshot `Last updated` must match the top entry date'
+
+invalid_heading_repo="$tmp_root/context-log-invalid-heading"
+init_repo "$invalid_heading_repo"
+"$repo_root/scripts/new-project.sh" "hook-test" "$invalid_heading_repo" >/dev/null
+replace_first_context_log_heading "$invalid_heading_repo/agent-vault/context-log.md" "bad heading format"
+git -C "$invalid_heading_repo" add agent-vault/context-log.md
+invalid_heading_output="$(run_hook_expect_failure "$invalid_heading_repo")"
+assert_output_contains "$invalid_heading_output" 'entry headings must start with `YYYY-MM-DD HH:MM local - <agent> - <topic>`'
+
+empty_entries_repo="$tmp_root/context-log-empty-entries"
+init_repo "$empty_entries_repo"
+"$repo_root/scripts/new-project.sh" "hook-test" "$empty_entries_repo" >/dev/null
+clear_context_log_entries "$empty_entries_repo/agent-vault/context-log.md"
+git -C "$empty_entries_repo" add agent-vault/context-log.md
+empty_entries_output="$(run_hook_expect_failure "$empty_entries_repo")"
+assert_output_contains "$empty_entries_output" 'must include at least one entry under `## Entries`'
 
 # shellcheck source=./lib/tracked-hooks.sh
 source "$script_dir/lib/tracked-hooks.sh"


### PR DESCRIPTION
## Summary
- validate staged `agent-vault/context-log.md` ordering and freshness in the tracked `pre-commit` hook
- document the enforced context-log entry heading format in the scaffold and hook docs
- add regression coverage for newest-first ordering and stale `last_updated` failures

Closes #79.

## Testing
- `bash scripts/test-session-metadata-hook.sh`
- `git diff --check`