### PR TITLE
Clarify canonical artifact ordering rules

### DIFF
--- a/scaffold/agent-vault/AGENTS.md
+++ b/scaffold/agent-vault/AGENTS.md
@@ -148,6 +148,17 @@
   - `agent-vault/decisions/DEC-###-<slug>.md` - decision record
 - `agent-vault/context/scratchpad.md` is temporary working memory only. Move lasting information into canonical files before finishing.
 
+## Artifact Ordering Rules
+Use the canonical ordering for each artifact type below instead of guessing based on recency alone.
+
+| Artifact | Ordering rule |
+| --- | --- |
+| `agent-vault/context-log.md`, `agent-vault/lessons.md` | Newest entry at top. |
+| `agent-vault/decision-log.md` | Newest active or changed decisions at top. |
+| `agent-vault/daily/YYYY-MM-DD.md` | Chronological within the day. Append new same-day work at the bottom. |
+| `agent-vault/design-log/` notes | One file per substantive session. Read the newest 3 notes first during session start. |
+| `agent-vault/context/handoffs/` notes | Read the note referenced by the latest `context-log.md` entry first; otherwise read the most recent handoff note. |
+
 ## Template Usage Rules
 - Use the bootstrap files in place. Do not create duplicate `README.md`, `plan.md`, `coding-standards.md`, `context-log.md`, `open-questions.md`, or `decision-log.md` notes elsewhere.
 - Create or update `agent-vault/daily/YYYY-MM-DD.md` on the first substantive work session of each local day. Reuse the same file for later sessions that day. Skip daily notes for trivial one-off requests.

--- a/scaffold/agent-vault/Templates/Daily Note.md
+++ b/scaffold/agent-vault/Templates/Daily Note.md
@@ -14,6 +14,7 @@ last_updated:
 - [ ]
 
 ## Work Log
+<!-- Keep same-day work chronological. Append new entries or added session sections at the bottom. -->
 - HH:MM - 
 
 ## Decisions / Key Updates

--- a/scaffold/agent-vault/daily/README.md
+++ b/scaffold/agent-vault/daily/README.md
@@ -6,6 +6,7 @@ Daily notes are supplemental. Durable decisions, open questions, and handoffs mu
 
 Read today's note first if it exists.
 Create or update `YYYY-MM-DD.md` on the first substantive work session of the day.
+Keep same-day content chronological: append new work log entries or added session sections at the bottom rather than inserting newer work at the top.
 
 Suggested filename:
 - `YYYY-MM-DD.md`

--- a/scaffold/agent-vault/shared-rules.md
+++ b/scaffold/agent-vault/shared-rules.md
@@ -143,6 +143,17 @@
   - `agent-vault/decisions/DEC-###-<slug>.md` - decision record
 - `agent-vault/context/scratchpad.md` is temporary working memory only. Move lasting information into canonical files before finishing.
 
+## Artifact Ordering Rules
+Use the canonical ordering for each artifact type below instead of guessing based on recency alone.
+
+| Artifact | Ordering rule |
+| --- | --- |
+| `agent-vault/context-log.md`, `agent-vault/lessons.md` | Newest entry at top. |
+| `agent-vault/decision-log.md` | Newest active or changed decisions at top. |
+| `agent-vault/daily/YYYY-MM-DD.md` | Chronological within the day. Append new same-day work at the bottom. |
+| `agent-vault/design-log/` notes | One file per substantive session. Read the newest 3 notes first during session start. |
+| `agent-vault/context/handoffs/` notes | Read the note referenced by the latest `context-log.md` entry first; otherwise read the most recent handoff note. |
+
 ## Template Usage Rules
 - Use the bootstrap files in place. Do not create duplicate `README.md`, `plan.md`, `coding-standards.md`, `context-log.md`, `open-questions.md`, or `decision-log.md` notes elsewhere.
 - Create or update `agent-vault/daily/YYYY-MM-DD.md` on the first substantive work session of each local day. Reuse the same file for later sessions that day. Skip daily notes for trivial one-off requests.


### PR DESCRIPTION
## Summary
This PR documents the canonical ordering rules for scaffold note artifacts so agents do not have to infer them from partial examples.

It adds a compact artifact-ordering section to the managed workflow docs, makes daily-note ordering explicit where agents edit those files, and preserves the existing `decision-log.md` nuance that active or changed decisions stay at the top.

Fixes #82.

## Files Changed
- `scaffold/agent-vault/shared-rules.md`
  Added a scannable artifact-ordering table as the canonical workflow rule.
- `scaffold/agent-vault/AGENTS.md`
  Mirrored the shared-rules change for Codex compatibility.
- `scaffold/agent-vault/daily/README.md`
  Added explicit daily-note guidance to keep same-day content chronological and append at the bottom.
- `scaffold/agent-vault/Templates/Daily Note.md`
  Added an inline comment at the `Work Log` edit point so the intended ordering is visible while writing.

## Verification
- `./scripts/check-policy-mirrors.sh`
  Passed.
- `git diff --check`
  Passed.
- Scaffold smoke test in a temporary repo:
  - Ran `scripts/new-project.sh` to seed a fresh repo.
  - Confirmed generated `agent-vault/AGENTS.md`, `agent-vault/shared-rules.md`, `agent-vault/daily/README.md`, and `agent-vault/Templates/Daily Note.md` contain the new ordering guidance.
  - Ran `scripts/update-project.sh <temp-repo> --dry-run --sync-templates`.
  Passed.

## Risks And Rollback
- Risk is low because this is docs-only and does not change hook enforcement or runtime behavior.
- Existing generated repos pick up the managed-file wording through normal `update-project.sh` sync for `shared-rules.md`, `AGENTS.md`, and `daily/README.md`.
- The `Templates/Daily Note.md` change remains template-only and therefore requires `--sync-templates` for existing repos that want it.
- Rollback is straightforward: revert this commit.

## Residual Gaps
- This PR intentionally does not add pre-commit enforcement for daily-note ordering.
- `design-log/README.md` and `context/handoffs/README.md` were reviewed for consistency and did not require changes.

## Docs Consistency
- No impact on `docs/design.md` detected.
- No top-level `README.md` change was required because the ambiguity lived in scaffold workflow docs and note templates.