### PR TITLE
Add managed worktree helpers

### DIFF
--- a/.github/workflows/scaffold-regression-checks.yml
+++ b/.github/workflows/scaffold-regression-checks.yml
@@ -5,12 +5,17 @@ on:
     paths:
       - "README.md"
       - "scaffold/agent-vault/**"
+      - "scaffold/root/scripts/**"
+      - "scaffold/root/docs/runbooks/**"
       - "scripts/new-project.sh"
       - "scripts/update-project.sh"
       - "scripts/test-gitignore-management.sh"
       - "scripts/test-coding-standards-sync.sh"
       - "scripts/test-decision-template-sync.sh"
       - "scripts/test-session-metadata-hook.sh"
+      - "scripts/test-new-worktree.sh"
+      - "scripts/test-remove-worktree.sh"
+      - "scripts/test-worktree-helper-sync.sh"
       - ".github/workflows/scaffold-regression-checks.yml"
   push:
     branches:
@@ -18,12 +23,17 @@ on:
     paths:
       - "README.md"
       - "scaffold/agent-vault/**"
+      - "scaffold/root/scripts/**"
+      - "scaffold/root/docs/runbooks/**"
       - "scripts/new-project.sh"
       - "scripts/update-project.sh"
       - "scripts/test-gitignore-management.sh"
       - "scripts/test-coding-standards-sync.sh"
       - "scripts/test-decision-template-sync.sh"
       - "scripts/test-session-metadata-hook.sh"
+      - "scripts/test-new-worktree.sh"
+      - "scripts/test-remove-worktree.sh"
+      - "scripts/test-worktree-helper-sync.sh"
       - ".github/workflows/scaffold-regression-checks.yml"
   workflow_dispatch:
 
@@ -41,3 +51,9 @@ jobs:
         run: bash scripts/test-decision-template-sync.sh
       - name: Verify session metadata hook behavior
         run: bash scripts/test-session-metadata-hook.sh
+      - name: Verify worktree creation helper
+        run: bash scripts/test-new-worktree.sh
+      - name: Verify worktree removal helper
+        run: bash scripts/test-remove-worktree.sh
+      - name: Verify worktree helper scaffold sync
+        run: bash scripts/test-worktree-helper-sync.sh

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The generated vault is plain Markdown and works directly in Obsidian.
    - Example: `./scripts/update-project.sh ~/workspaces/harrier`
    - To migrate unmanaged root wrappers to managed versions:
      - `./scripts/update-project.sh <repo-path> --migrate-root`
+   - To migrate unmanaged root worktree helper scripts to managed versions:
+     - `./scripts/update-project.sh <repo-path> --migrate-root-scripts`
 4. `new-project.sh` and `update-project.sh` automatically enable the tracked metadata hook in the current clone when `core.hooksPath` is not already customized.
 5. For additional clones, or when you want to opt into the tracked hook manually:
    - `git -C <repo-path> config core.hooksPath agent-vault/_assets/hooks`
@@ -68,6 +70,8 @@ This repo should stay template-only. Do not store project-specific session logs 
   - `scaffold/agent-vault/`
 - Project-root scaffold copied into project repos lives at:
   - `scaffold/root/`
+  - including optional helper scripts under `scaffold/root/scripts/` and
+    runbooks under `scaffold/root/docs/runbooks/`
 
 If you want changes to propagate to future projects, edit files under `scaffold/agent-vault/` and `scaffold/root/`.
 
@@ -91,6 +95,9 @@ Run the scaffold regression scripts locally when changing bootstrap, sync, or tr
 - `bash scripts/test-coding-standards-sync.sh`
 - `bash scripts/test-decision-template-sync.sh`
 - `bash scripts/test-session-metadata-hook.sh`
+- `bash scripts/test-new-worktree.sh`
+- `bash scripts/test-remove-worktree.sh`
+- `bash scripts/test-worktree-helper-sync.sh`
 
 CI also runs these checks via `.github/workflows/scaffold-regression-checks.yml`.
 
@@ -114,9 +121,14 @@ CI also runs these checks via `.github/workflows/scaffold-regression-checks.yml`
   - `<repo>/AGENTS.md`
   - `<repo>/CLAUDE.md`
   - `<repo>/GEMINI.md`
+- Root helper scripts (managed only when the script has the `agent-vault-managed`
+  marker, or when created by `update-project.sh` because it was missing):
+  - `<repo>/scripts/new-worktree.sh`
+  - `<repo>/scripts/remove-worktree.sh`
 - Seeded if missing:
   - `<repo>/.github/pull_request_template.md`
   - `<repo>/docs/design.md`
+  - `<repo>/docs/runbooks/parallel-agent-worktrees.md`
   - `<repo>/agent-vault/project-context.md`
   - `<repo>/agent-vault/project-commands.md`
   - `<repo>/agent-vault/lessons.md`
@@ -124,6 +136,9 @@ CI also runs these checks via `.github/workflows/scaffold-regression-checks.yml`
 `<repo>/agent-vault/coding-standards.md` remains project-owned by default. `update-project.sh` does not replace it unless you explicitly pass `--sync-coding-standards`.
 
 If an existing root policy file does not have the managed marker, `update-project.sh` leaves it unchanged and reports a skip notice suggesting `--migrate-root`.
+If an existing root worktree helper script does not have the managed marker,
+`update-project.sh` leaves it unchanged and reports a skip notice suggesting
+`--migrate-root-scripts`.
 
 Template refresh is opt-in:
 - `./scripts/update-project.sh <repo-path> --sync-templates` updates `agent-vault/Templates/` from the scaffold and backs up replaced files under `agent-vault/context/updates/<timestamp>/`.
@@ -135,6 +150,26 @@ Coding standards refresh is also opt-in:
 
 ### Migrating Root Wrappers (`--migrate-root`)
 When running `update-project.sh` with `--migrate-root`, unmanaged root wrappers (those missing the `agent-vault-managed` marker) are backed up and replaced with the current scaffold versions. This is useful for workspaces created before root wrapper management was introduced.
+
+### Migrating Root Worktree Helpers (`--migrate-root-scripts`)
+Generated projects include optional helpers for creating and removing
+issue-scoped Git worktrees:
+
+- `<repo>/scripts/new-worktree.sh`
+- `<repo>/scripts/remove-worktree.sh`
+
+When running `update-project.sh` normally, missing helper scripts are created
+from the scaffold and executable permissions are enforced. Existing helper
+scripts with the managed marker are updated from the scaffold. Existing helper
+scripts without the marker are skipped unless you pass
+`--migrate-root-scripts`, which backs up and replaces them with the managed
+versions.
+
+The default worktree location is a sibling directory named
+`../<repo-name>-wt/`. A writing agent can run the setup helper from the original
+checkout, but the generated runbook recommends launching actual writing
+sessions from inside the generated worktree so agent sandbox permissions use
+that worktree as the active workspace.
 
 When a managed file changes, the script backs up the previous version under:
 - `<repo>/agent-vault/context/updates/<timestamp>/...`
@@ -198,7 +233,9 @@ It also creates project-root files when missing:
 - `<repo-path>/CLAUDE.md` -> imports `agent-vault/CLAUDE.md` and `agent-vault/review-policy.md`
 - `<repo-path>/GEMINI.md` -> imports `agent-vault/GEMINI.md` and `agent-vault/review-policy.md`
 - `<repo-path>/docs/design.md` -> starter architecture/design document with embedded Mermaid diagrams
+- `<repo-path>/docs/runbooks/parallel-agent-worktrees.md` -> optional workflow for one issue-scoped Git worktree per writing agent
 - `<repo-path>/.github/pull_request_template.md` -> standardized agent PR body template
+- `<repo-path>/scripts/new-worktree.sh` and `<repo-path>/scripts/remove-worktree.sh` -> managed helpers for parallel-agent Git worktree setup and cleanup
 - Bootstrap behavior: `new-project.sh` hydrates project metadata placeholders (`repo_reference`, active branch, dates) in the baseline `agent-vault/` docs, seeds non-empty baseline content in `agent-vault/README.md`, `plan.md`, `coding-standards.md`, and `context-log.md`, copies structured starter templates for `project-context.md` and `project-commands.md`, and copies scaffold helper docs such as `agent-vault/design-log/README.md` plus `docs/design.md`.
 
 If root files already exist, the script leaves them unchanged unless `--migrate-existing-root-md` is provided.

--- a/scaffold/agent-vault/project-commands.md
+++ b/scaffold/agent-vault/project-commands.md
@@ -22,6 +22,27 @@ update this file when the canonical workflow changes.
 # Add local development or runtime commands here.
 ```
 
+## Parallel Worktree Commands
+
+```bash
+# Create one issue-scoped worktree for Codex
+./scripts/new-worktree.sh --agent codex --issue 123 --slug feature-slice
+
+# Create one issue-scoped worktree for Claude
+./scripts/new-worktree.sh --agent claude --issue 124 --slug review-cleanup
+
+# Create one issue-scoped worktree for Gemini
+./scripts/new-worktree.sh --agent gemini --issue 125 --slug docs-followup
+
+# After merge, remove the worktree from the main checkout or another safe cwd
+./scripts/remove-worktree.sh --branch codex/123-feature-slice --delete-branch
+```
+
+The helper creates sibling worktrees under `../<repo-name>-wt/` by default.
+Launch the writing agent from inside the generated worktree so that agent
+sandbox permissions use that worktree as the active workspace. Keep the main
+checkout for integration, review, and post-merge cleanup.
+
 ## Release / Operations Commands
 
 ```bash

--- a/scaffold/root/docs/runbooks/parallel-agent-worktrees.md
+++ b/scaffold/root/docs/runbooks/parallel-agent-worktrees.md
@@ -1,0 +1,179 @@
+# Parallel Agent Worktrees
+
+## Purpose
+Use one issue-scoped Git worktree per writing agent so multiple agents can work
+from the same repository without editing the same checkout or branch.
+
+The core rule is:
+
+- one issue
+- one branch
+- one worktree
+- one writing agent
+
+Terminal multiplexers are optional and intentionally not part of this workflow.
+The helpers only create or remove Git worktrees.
+
+## Why Worktrees
+Use Git worktrees when you want to:
+
+- work on multiple issues from the same repository clone
+- keep each issue on its own branch and directory
+- avoid branch switching churn in one checkout
+- keep agents from editing the same working tree
+
+Do not point multiple writing agents at the same checkout.
+
+## Create A Worktree
+From the main checkout:
+
+```bash
+./scripts/new-worktree.sh --agent codex --issue 123 --slug feature-slice
+```
+
+Other agent examples:
+
+```bash
+./scripts/new-worktree.sh --agent claude --issue 124 --slug review-cleanup
+./scripts/new-worktree.sh --agent gemini --issue 125 --slug docs-followup
+```
+
+By default the helper creates sibling worktrees under:
+
+```text
+../<repo-name>-wt/
+```
+
+For a repository named `example-app`, the layout is:
+
+```text
+example-app/                                  # main checkout
+example-app-wt/codex-123-feature-slice/       # issue worktree
+example-app-wt/claude-124-review-cleanup/     # issue worktree
+example-app-wt/gemini-125-docs-followup/      # issue worktree
+```
+
+The helper creates:
+
+- a branch named like `codex/123-feature-slice`
+- a worktree directory named like `codex-123-feature-slice`
+
+Then it prints the `cd` command and a best-effort launch hint such as `codex`,
+`claude`, or `gemini`.
+
+## Custom Worktree Root
+Use `--root` to place worktrees somewhere else:
+
+```bash
+./scripts/new-worktree.sh \
+  --agent codex \
+  --issue 126 \
+  --slug api-refactor \
+  --root ../custom-worktrees
+```
+
+Relative `--root` paths are resolved from the main checkout.
+
+## Agent Sandbox Permissions
+It is fine for an agent launched from the original checkout to run the setup
+helper:
+
+```bash
+./scripts/new-worktree.sh --agent codex --issue 123 --slug feature-slice
+```
+
+For actual writing work, launch a new agent session from inside the generated
+worktree:
+
+```bash
+cd ../example-app-wt/codex-123-feature-slice
+codex
+```
+
+Use the same pattern for other agents:
+
+```bash
+cd ../example-app-wt/claude-124-review-cleanup
+claude
+
+cd ../example-app-wt/gemini-125-docs-followup
+gemini
+```
+
+Many agent clients treat the launch directory as the active writable workspace.
+If an agent launched from the main checkout edits a sibling worktree, the client
+may ask for extra approval prompts or deny writes. If your client supports
+trusted or writable roots, you can trust the sibling worktree root, but launching
+inside the assigned worktree is the default path.
+
+## Recommended Workflow
+
+### 1. Create the worktree
+
+```bash
+./scripts/new-worktree.sh --agent codex --issue 123 --slug feature-slice
+```
+
+### 2. Enter the new directory
+
+```bash
+cd ../example-app-wt/codex-123-feature-slice
+```
+
+### 3. Launch the writing agent
+
+```bash
+codex
+```
+
+### 4. Run issue-local checks from that worktree
+Run the relevant project commands from `agent-vault/project-commands.md`.
+
+### 5. After merge, remove the worktree from a safe directory
+From the main checkout or another directory outside the target worktree:
+
+```bash
+./scripts/remove-worktree.sh --branch codex/123-feature-slice --delete-branch
+```
+
+The cleanup helper refuses to remove a worktree containing the current working
+directory. This avoids leaving an agent session pointed at a deleted directory.
+
+Only use `--delete-branch` after the issue branch is merged or no longer needed.
+Add `--force` only when you intentionally want to remove a dirty disposable
+worktree.
+
+## Existing Project Command Snippet
+For existing projects whose `agent-vault/project-commands.md` predates these
+helpers, copy this section into that file if you want the workflow listed with
+the project commands:
+
+```md
+## Parallel Worktree Commands
+
+\`\`\`bash
+# Create one issue-scoped worktree for Codex
+./scripts/new-worktree.sh --agent codex --issue 123 --slug feature-slice
+
+# Create one issue-scoped worktree for Claude
+./scripts/new-worktree.sh --agent claude --issue 124 --slug review-cleanup
+
+# Create one issue-scoped worktree for Gemini
+./scripts/new-worktree.sh --agent gemini --issue 125 --slug docs-followup
+
+# After merge, remove the worktree from the main checkout or another safe cwd
+./scripts/remove-worktree.sh --branch codex/123-feature-slice --delete-branch
+\`\`\`
+```
+
+## Notes
+- The create helper is idempotent for the same agent, issue, and slug. If the
+  worktree already exists, it prints the existing path instead of creating a
+  duplicate.
+- The remove helper checks whether the main checkout's `.venv` has an editable
+  install path pointing inside the target worktree. If so, it refuses removal so
+  local tools do not keep importing from a deleted path.
+- Parallel branches often conflict in `agent-vault/context-log.md`,
+  same-day daily notes, and nearby design-log notes. Resolve those conflicts by
+  keeping all valid entries and preserving the ordering rules from
+  `agent-vault/AGENTS.md`.

--- a/scaffold/root/docs/runbooks/parallel-agent-worktrees.md
+++ b/scaffold/root/docs/runbooks/parallel-agent-worktrees.md
@@ -72,7 +72,8 @@ Use `--root` to place worktrees somewhere else:
   --root ../custom-worktrees
 ```
 
-Relative `--root` paths are resolved from the main checkout.
+Relative `--root` paths are resolved from the main checkout, not your current
+directory.
 
 ## Agent Sandbox Permissions
 It is fine for an agent launched from the original checkout to run the setup

--- a/scaffold/root/scripts/new-worktree.sh
+++ b/scaffold/root/scripts/new-worktree.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# agent-vault-managed: helper-script; file=new-worktree.sh
+
+# Create one issue-scoped git worktree for one writing agent.
+#
+# This only creates or reuses the branch + worktree and prints the next command
+# to run from that directory. Launch the writing agent from inside the worktree
+# so agent sandboxes use that worktree as their active workspace.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+REPO_NAME="$(basename "$PROJECT_DIR")"
+DEFAULT_ROOT="$(dirname "$PROJECT_DIR")/${REPO_NAME}-wt"
+
+usage() {
+    cat <<EOF
+Usage: $0 --agent NAME --issue NUMBER [--slug TEXT] [--base REF] [--root DIR]
+
+Create or reuse one issue-scoped worktree for one writing agent.
+
+Options:
+  --agent NAME   Agent label, for example: codex, claude, gemini
+  --issue N      Issue number
+  --slug TEXT    Optional short slug, for example: feature-slice
+  --base REF     Optional base ref. Defaults to origin/main when available,
+                 otherwise main, otherwise the current branch.
+  --root DIR     Optional worktree root. Relative paths are resolved from the
+                 current repo root. Default: $DEFAULT_ROOT
+  -h, --help     Show this help
+
+Examples:
+  $0 --agent codex --issue 123 --slug feature-slice
+  $0 --agent claude --issue 124 --slug review-cleanup
+  $0 --agent gemini --issue 125 --slug docs-followup
+EOF
+}
+
+die() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+normalize_token() {
+    local raw="$1"
+    printf '%s' "$raw" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g'
+}
+
+resolve_root_dir() {
+    local raw="$1"
+    if [[ "$raw" = /* ]]; then
+        printf '%s\n' "$raw"
+    else
+        printf '%s\n' "$PROJECT_DIR/$raw"
+    fi
+}
+
+default_base_ref() {
+    if git -C "$PROJECT_DIR" rev-parse --verify --quiet "refs/remotes/origin/main" >/dev/null; then
+        printf 'origin/main\n'
+        return
+    fi
+    if git -C "$PROJECT_DIR" rev-parse --verify --quiet "refs/heads/main" >/dev/null; then
+        printf 'main\n'
+        return
+    fi
+    git -C "$PROJECT_DIR" branch --show-current
+}
+
+find_branch_worktree() {
+    local branch_name="$1"
+    local current_worktree=""
+    local line=""
+
+    while IFS= read -r line; do
+        case "$line" in
+            worktree\ *)
+                current_worktree="${line#worktree }"
+                ;;
+            branch\ refs/heads/*)
+                if [[ "${line#branch refs/heads/}" == "$branch_name" ]]; then
+                    printf '%s\n' "$current_worktree"
+                    return 0
+                fi
+                ;;
+        esac
+    done < <(git -C "$PROJECT_DIR" worktree list --porcelain)
+
+    return 1
+}
+
+launch_hint() {
+    local normalized_agent="$1"
+    case "$normalized_agent" in
+        codex*)
+            printf 'codex\n'
+            ;;
+        claude*|claude-code*)
+            printf 'claude\n'
+            ;;
+        gemini*)
+            printf 'gemini\n'
+            ;;
+        *)
+            printf '\n'
+            ;;
+    esac
+}
+
+print_next_steps() {
+    local worktree_path="$1"
+    local normalized_agent="$2"
+    local hint
+
+    hint="$(launch_hint "$normalized_agent")"
+
+    echo ""
+    echo "Next:"
+    echo "  cd $worktree_path"
+    if [[ -n "$hint" ]]; then
+        echo "  $hint"
+    else
+        echo "  # launch your writing agent from this directory"
+    fi
+}
+
+require_git_repo() {
+    git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+        || die "Not inside a git worktree: $PROJECT_DIR"
+}
+
+AGENT=""
+ISSUE=""
+SLUG=""
+BASE_REF=""
+ROOT_DIR="$DEFAULT_ROOT"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --agent)
+            [[ $# -ge 2 ]] || die "Missing value for --agent"
+            AGENT="$2"
+            shift 2
+            ;;
+        --issue)
+            [[ $# -ge 2 ]] || die "Missing value for --issue"
+            ISSUE="$2"
+            shift 2
+            ;;
+        --slug)
+            [[ $# -ge 2 ]] || die "Missing value for --slug"
+            SLUG="$2"
+            shift 2
+            ;;
+        --base)
+            [[ $# -ge 2 ]] || die "Missing value for --base"
+            BASE_REF="$2"
+            shift 2
+            ;;
+        --root)
+            [[ $# -ge 2 ]] || die "Missing value for --root"
+            ROOT_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "Unknown option: $1"
+            ;;
+    esac
+done
+
+require_git_repo
+
+[[ -n "$AGENT" ]] || die "--agent is required"
+[[ -n "$ISSUE" ]] || die "--issue is required"
+[[ "$ISSUE" =~ ^[0-9]+$ ]] || die "--issue must be numeric"
+
+NORMALIZED_AGENT="$(normalize_token "$AGENT")"
+[[ -n "$NORMALIZED_AGENT" ]] || die "--agent must contain letters or numbers"
+
+NORMALIZED_SLUG=""
+if [[ -n "$SLUG" ]]; then
+    NORMALIZED_SLUG="$(normalize_token "$SLUG")"
+    [[ -n "$NORMALIZED_SLUG" ]] || die "--slug must contain letters or numbers"
+fi
+
+ROOT_DIR="$(resolve_root_dir "$ROOT_DIR")"
+mkdir -p "$ROOT_DIR"
+ROOT_DIR="$(cd "$ROOT_DIR" && pwd -P)"
+
+NAME_SUFFIX="$ISSUE"
+if [[ -n "$NORMALIZED_SLUG" ]]; then
+    NAME_SUFFIX="${NAME_SUFFIX}-${NORMALIZED_SLUG}"
+fi
+
+BRANCH_NAME="${NORMALIZED_AGENT}/${NAME_SUFFIX}"
+WORKTREE_NAME="${NORMALIZED_AGENT}-${NAME_SUFFIX}"
+WORKTREE_PATH="${ROOT_DIR}/${WORKTREE_NAME}"
+
+EXISTING_WORKTREE="$(find_branch_worktree "$BRANCH_NAME" || true)"
+if [[ -n "$EXISTING_WORKTREE" && ! -d "$EXISTING_WORKTREE" ]]; then
+    git -C "$PROJECT_DIR" worktree prune >/dev/null 2>&1 || true
+    EXISTING_WORKTREE="$(find_branch_worktree "$BRANCH_NAME" || true)"
+fi
+if [[ -n "$EXISTING_WORKTREE" ]]; then
+    echo "Worktree already exists:"
+    echo "  Path: $EXISTING_WORKTREE"
+    echo "  Branch: $BRANCH_NAME"
+    print_next_steps "$EXISTING_WORKTREE" "$NORMALIZED_AGENT"
+    exit 0
+fi
+
+if [[ -e "$WORKTREE_PATH" ]]; then
+    die "Target path already exists: $WORKTREE_PATH"
+fi
+
+if [[ -z "$BASE_REF" ]]; then
+    BASE_REF="$(default_base_ref)"
+fi
+[[ -n "$BASE_REF" ]] || die "Could not determine a base ref"
+git -C "$PROJECT_DIR" rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null \
+    || die "Base ref not found: $BASE_REF"
+
+if git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+    git -C "$PROJECT_DIR" worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+else
+    git -C "$PROJECT_DIR" worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" "$BASE_REF"
+fi
+
+echo "Created worktree:"
+echo "  Path: $WORKTREE_PATH"
+echo "  Branch: $BRANCH_NAME"
+echo "  Base: $BASE_REF"
+print_next_steps "$WORKTREE_PATH" "$NORMALIZED_AGENT"

--- a/scaffold/root/scripts/new-worktree.sh
+++ b/scaffold/root/scripts/new-worktree.sh
@@ -190,18 +190,14 @@ if [[ -n "$SLUG" ]]; then
     [[ -n "$NORMALIZED_SLUG" ]] || die "--slug must contain letters or numbers"
 fi
 
-ROOT_DIR="$(resolve_root_dir "$ROOT_DIR")"
-mkdir -p "$ROOT_DIR"
-ROOT_DIR="$(cd "$ROOT_DIR" && pwd -P)"
-
 NAME_SUFFIX="$ISSUE"
 if [[ -n "$NORMALIZED_SLUG" ]]; then
     NAME_SUFFIX="${NAME_SUFFIX}-${NORMALIZED_SLUG}"
 fi
 
+ROOT_DIR="$(resolve_root_dir "$ROOT_DIR")"
 BRANCH_NAME="${NORMALIZED_AGENT}/${NAME_SUFFIX}"
 WORKTREE_NAME="${NORMALIZED_AGENT}-${NAME_SUFFIX}"
-WORKTREE_PATH="${ROOT_DIR}/${WORKTREE_NAME}"
 
 EXISTING_WORKTREE="$(find_branch_worktree "$BRANCH_NAME" || true)"
 if [[ -n "$EXISTING_WORKTREE" && ! -d "$EXISTING_WORKTREE" ]]; then
@@ -216,16 +212,20 @@ if [[ -n "$EXISTING_WORKTREE" ]]; then
     exit 0
 fi
 
-if [[ -e "$WORKTREE_PATH" ]]; then
-    die "Target path already exists: $WORKTREE_PATH"
-fi
-
 if [[ -z "$BASE_REF" ]]; then
     BASE_REF="$(default_base_ref)"
 fi
 [[ -n "$BASE_REF" ]] || die "Could not determine a base ref"
 git -C "$PROJECT_DIR" rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null \
     || die "Base ref not found: $BASE_REF"
+
+mkdir -p "$ROOT_DIR"
+ROOT_DIR="$(cd "$ROOT_DIR" && pwd -P)"
+WORKTREE_PATH="${ROOT_DIR}/${WORKTREE_NAME}"
+
+if [[ -e "$WORKTREE_PATH" ]]; then
+    die "Target path already exists: $WORKTREE_PATH"
+fi
 
 if git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
     git -C "$PROJECT_DIR" worktree add "$WORKTREE_PATH" "$BRANCH_NAME"

--- a/scaffold/root/scripts/remove-worktree.sh
+++ b/scaffold/root/scripts/remove-worktree.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# agent-vault-managed: helper-script; file=remove-worktree.sh
+
+# Safely remove one issue-scoped git worktree created for an agent session.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+
+usage() {
+    cat <<EOF
+Usage: $0 (--branch NAME | --path DIR) [--delete-branch] [--force]
+
+Remove a non-primary git worktree from a safe working directory.
+
+Options:
+  --branch NAME     Local branch name attached to the worktree to remove
+  --path DIR        Worktree path to remove. Relative paths are resolved from
+                    the current repo root.
+  --delete-branch   Delete the local branch with git branch -D after removal.
+                    Use only after the PR is merged or the branch is disposable.
+  --force           Pass --force to git worktree remove.
+  -h, --help        Show this help
+
+Examples:
+  $0 --branch codex/123-feature-slice
+  $0 --branch codex/123-feature-slice --delete-branch
+  $0 --path ../example-app-wt/codex-123-feature-slice --force
+EOF
+}
+
+die() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+resolve_path() {
+    local raw="$1"
+    if [[ "$raw" = /* ]]; then
+        printf '%s\n' "$raw"
+    else
+        printf '%s\n' "$PROJECT_DIR/$raw"
+    fi
+}
+
+canonical_dir() {
+    local path="$1"
+    (
+        cd "$path"
+        pwd -P
+    )
+}
+
+find_shared_editable_binding() {
+    local target_path="$1"
+    local venv_dir="$PROJECT_DIR/.venv"
+    local pth_file=""
+    local bound_path=""
+    local line=""
+
+    [[ -d "$venv_dir" ]] || return 1
+
+    while IFS= read -r -d '' pth_file; do
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            [[ -n "$line" ]] || continue
+            [[ "$line" != \#* ]] || continue
+            [[ -d "$line" ]] || continue
+            bound_path="$(canonical_dir "$line" 2>/dev/null || true)"
+            [[ -n "$bound_path" ]] || continue
+            if [[ "$bound_path" == "$target_path" || "$bound_path" == "$target_path/"* ]]; then
+                printf '%s\n' "$bound_path"
+                return 0
+            fi
+        done < "$pth_file"
+    done < <(find "$venv_dir" -type f -path '*/site-packages/*.pth' -print0 2>/dev/null)
+
+    return 1
+}
+
+find_branch_worktree() {
+    local branch_name="$1"
+    local current_worktree=""
+    local line=""
+
+    while IFS= read -r line; do
+        case "$line" in
+            worktree\ *)
+                current_worktree="${line#worktree }"
+                ;;
+            branch\ refs/heads/*)
+                if [[ "${line#branch refs/heads/}" == "$branch_name" ]]; then
+                    printf '%s\n' "$current_worktree"
+                    return 0
+                fi
+                ;;
+        esac
+    done < <(git -C "$PROJECT_DIR" worktree list --porcelain)
+
+    return 1
+}
+
+find_worktree_branch() {
+    local target_path="$1"
+    local current_worktree=""
+    local current_branch=""
+    local line=""
+
+    while IFS= read -r line; do
+        case "$line" in
+            worktree\ *)
+                current_worktree="${line#worktree }"
+                ;;
+            branch\ refs/heads/*)
+                current_branch="${line#branch refs/heads/}"
+                if [[ "$(canonical_dir "$current_worktree")" == "$target_path" ]]; then
+                    printf '%s\n' "$current_branch"
+                    return 0
+                fi
+                ;;
+        esac
+    done < <(git -C "$PROJECT_DIR" worktree list --porcelain)
+
+    return 1
+}
+
+require_git_repo() {
+    git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+        || die "Not inside a git worktree: $PROJECT_DIR"
+}
+
+ensure_safe_cwd() {
+    local target_path="$1"
+    local pwd_real
+
+    pwd_real="$(pwd -P)"
+    case "$pwd_real/" in
+        "$target_path/"*)
+            die "Refusing to remove worktree containing current working directory: $target_path. Run this command from $PROJECT_DIR or /tmp and retry."
+            ;;
+    esac
+}
+
+BRANCH_NAME=""
+TARGET_PATH=""
+DELETE_BRANCH=false
+FORCE_REMOVE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --branch)
+            [[ $# -ge 2 ]] || die "Missing value for --branch"
+            BRANCH_NAME="$2"
+            shift 2
+            ;;
+        --path)
+            [[ $# -ge 2 ]] || die "Missing value for --path"
+            TARGET_PATH="$2"
+            shift 2
+            ;;
+        --delete-branch)
+            DELETE_BRANCH=true
+            shift
+            ;;
+        --force)
+            FORCE_REMOVE=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "Unknown option: $1"
+            ;;
+    esac
+done
+
+require_git_repo
+
+if [[ -z "$BRANCH_NAME" && -z "$TARGET_PATH" ]]; then
+    die "Either --branch or --path is required"
+fi
+
+if [[ -n "$BRANCH_NAME" ]]; then
+    resolved_path="$(find_branch_worktree "$BRANCH_NAME" || true)"
+    [[ -n "$resolved_path" ]] || die "No worktree found for branch: $BRANCH_NAME"
+    resolved_path="$(canonical_dir "$resolved_path")"
+    if [[ -n "$TARGET_PATH" ]]; then
+        TARGET_PATH="$(canonical_dir "$(resolve_path "$TARGET_PATH")")"
+        [[ "$TARGET_PATH" == "$resolved_path" ]] \
+            || die "--branch and --path refer to different worktrees"
+    else
+        TARGET_PATH="$resolved_path"
+    fi
+else
+    TARGET_PATH="$(canonical_dir "$(resolve_path "$TARGET_PATH")")"
+fi
+
+[[ -d "$TARGET_PATH" ]] || die "Worktree path does not exist: $TARGET_PATH"
+
+if [[ -z "$BRANCH_NAME" ]]; then
+    BRANCH_NAME="$(find_worktree_branch "$TARGET_PATH" || true)"
+fi
+
+if [[ "$DELETE_BRANCH" == true ]]; then
+    [[ -n "$BRANCH_NAME" ]] || die "--delete-branch requires a branch-backed worktree"
+fi
+
+[[ "$TARGET_PATH" != "$PROJECT_DIR" ]] \
+    || die "Refusing to remove primary checkout: $PROJECT_DIR"
+
+ensure_safe_cwd "$TARGET_PATH"
+
+bound_editable_path="$(find_shared_editable_binding "$TARGET_PATH" || true)"
+if [[ -n "$bound_editable_path" ]]; then
+    die "Refusing to remove worktree while the shared .venv editable install points inside it: $bound_editable_path. Reinstall the editable package from the main checkout first, then retry."
+fi
+
+if [[ "$FORCE_REMOVE" == true ]]; then
+    git -C "$PROJECT_DIR" worktree remove "$TARGET_PATH" --force
+else
+    git -C "$PROJECT_DIR" worktree remove "$TARGET_PATH"
+fi
+
+echo "Removed worktree:"
+echo "  Path: $TARGET_PATH"
+if [[ -n "$BRANCH_NAME" ]]; then
+    echo "  Branch: $BRANCH_NAME"
+fi
+
+if [[ "$DELETE_BRANCH" == true ]]; then
+    git -C "$PROJECT_DIR" branch -D "$BRANCH_NAME"
+fi

--- a/scaffold/root/scripts/remove-worktree.sh
+++ b/scaffold/root/scripts/remove-worktree.sh
@@ -47,7 +47,7 @@ resolve_path() {
 canonical_dir() {
     local path="$1"
     (
-        cd "$path"
+        cd "$path" || return 1
         pwd -P
     )
 }
@@ -104,6 +104,7 @@ find_worktree_branch() {
     local target_path="$1"
     local current_worktree=""
     local current_branch=""
+    local current_worktree_real=""
     local line=""
 
     while IFS= read -r line; do
@@ -113,7 +114,8 @@ find_worktree_branch() {
                 ;;
             branch\ refs/heads/*)
                 current_branch="${line#branch refs/heads/}"
-                if [[ "$(canonical_dir "$current_worktree")" == "$target_path" ]]; then
+                current_worktree_real="$(canonical_dir "$current_worktree" 2>/dev/null || true)"
+                if [[ "$current_worktree_real" == "$target_path" ]]; then
                     printf '%s\n' "$current_branch"
                     return 0
                 fi
@@ -185,16 +187,27 @@ fi
 if [[ -n "$BRANCH_NAME" ]]; then
     resolved_path="$(find_branch_worktree "$BRANCH_NAME" || true)"
     [[ -n "$resolved_path" ]] || die "No worktree found for branch: $BRANCH_NAME"
-    resolved_path="$(canonical_dir "$resolved_path")"
+    if [[ ! -d "$resolved_path" ]]; then
+        git -C "$PROJECT_DIR" worktree prune >/dev/null 2>&1 || true
+        die "Worktree record for branch '$BRANCH_NAME' points to a missing directory. Stale metadata was pruned; rerun this command to remove the remaining branch."
+    fi
+    resolved_path="$(canonical_dir "$resolved_path")" \
+        || die "Worktree path does not exist: $resolved_path"
     if [[ -n "$TARGET_PATH" ]]; then
-        TARGET_PATH="$(canonical_dir "$(resolve_path "$TARGET_PATH")")"
+        raw_target_path="$(resolve_path "$TARGET_PATH")"
+        [[ -d "$raw_target_path" ]] || die "Worktree path does not exist: $raw_target_path"
+        TARGET_PATH="$(canonical_dir "$raw_target_path")" \
+            || die "Worktree path does not exist: $raw_target_path"
         [[ "$TARGET_PATH" == "$resolved_path" ]] \
             || die "--branch and --path refer to different worktrees"
     else
         TARGET_PATH="$resolved_path"
     fi
 else
-    TARGET_PATH="$(canonical_dir "$(resolve_path "$TARGET_PATH")")"
+    raw_target_path="$(resolve_path "$TARGET_PATH")"
+    [[ -d "$raw_target_path" ]] || die "Worktree path does not exist: $raw_target_path"
+    TARGET_PATH="$(canonical_dir "$raw_target_path")" \
+        || die "Worktree path does not exist: $raw_target_path"
 fi
 
 [[ -d "$TARGET_PATH" ]] || die "Worktree path does not exist: $TARGET_PATH"

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -319,7 +319,10 @@ for required in \
   "$root_scaffold_dir/CLAUDE.md" \
   "$root_scaffold_dir/GEMINI.md" \
   "$root_scaffold_dir/.github/pull_request_template.md" \
-  "$root_scaffold_dir/docs/design.md"
+  "$root_scaffold_dir/docs/design.md" \
+  "$root_scaffold_dir/docs/runbooks/parallel-agent-worktrees.md" \
+  "$root_scaffold_dir/scripts/new-worktree.sh" \
+  "$root_scaffold_dir/scripts/remove-worktree.sh"
 do
   if [[ ! -f "$required" ]]; then
     echo "Error: missing root scaffold file: $required"
@@ -444,11 +447,30 @@ seed_root_file_if_missing() {
   echo "Created: $destination_rel"
 }
 
+seed_root_executable_file_if_missing() {
+  local source_path="$1"
+  local destination_path="$2"
+  local destination_existed="false"
+
+  if [[ -e "$destination_path" ]]; then
+    destination_existed="true"
+  fi
+
+  seed_root_file_if_missing "$source_path" "$destination_path"
+
+  if [[ "$destination_existed" == "false" && -f "$destination_path" ]]; then
+    chmod +x "$destination_path"
+  fi
+}
+
 process_root_policy_file "AGENTS.md" "$project_dir/AGENTS.md" "$ROOT_AGENTS_MARKER"
 process_root_policy_file "CLAUDE.md" "$project_dir/CLAUDE.md" "$ROOT_CLAUDE_MARKER"
 process_root_policy_file "GEMINI.md" "$project_dir/GEMINI.md" "$ROOT_GEMINI_MARKER"
 seed_root_file_if_missing "$root_scaffold_dir/.github/pull_request_template.md" "$canonical_repo_path/.github/pull_request_template.md"
 seed_root_file_if_missing "$root_scaffold_dir/docs/design.md" "$canonical_repo_path/docs/design.md"
+seed_root_file_if_missing "$root_scaffold_dir/docs/runbooks/parallel-agent-worktrees.md" "$canonical_repo_path/docs/runbooks/parallel-agent-worktrees.md"
+seed_root_executable_file_if_missing "$root_scaffold_dir/scripts/new-worktree.sh" "$canonical_repo_path/scripts/new-worktree.sh"
+seed_root_executable_file_if_missing "$root_scaffold_dir/scripts/remove-worktree.sh" "$canonical_repo_path/scripts/remove-worktree.sh"
 
 ensure_managed_gitignore_entries "$canonical_repo_path"
 hook_rc=0

--- a/scripts/test-new-worktree.sh
+++ b/scripts/test-new-worktree.sh
@@ -59,6 +59,19 @@ assert_path_exists() {
   fi
 }
 
+assert_path_missing() {
+  local path="$1"
+  local label="$2"
+
+  if [[ ! -e "$path" ]]; then
+    echo "PASS: $label"
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $label - unexpected path still exists: $path" >&2
+    failed=$((failed + 1))
+  fi
+}
+
 assert_path_under_tmp() {
   local path="$1"
   local label="$2"
@@ -179,6 +192,27 @@ rc=0
 output="$(run_new_worktree "$working" --agent codex 2>&1)" || rc=$?
 assert_exit_code 1 "$rc" "missing-issue exits 1"
 assert_output_contains "$output" "--issue is required" "missing-issue shows error"
+
+# --- Test 7: Invalid issue values fail clearly ---
+rc=0
+output="$(run_new_worktree "$working" --agent codex --issue abc 2>&1)" || rc=$?
+assert_exit_code 1 "$rc" "non-numeric-issue exits 1"
+assert_output_contains "$output" "--issue must be numeric" "non-numeric-issue shows error"
+
+# --- Test 8: Agent values that normalize to empty fail clearly ---
+rc=0
+output="$(run_new_worktree "$working" --agent "!!!" --issue 127 2>&1)" || rc=$?
+assert_exit_code 1 "$rc" "empty-normalized-agent exits 1"
+assert_output_contains "$output" "--agent must contain letters or numbers" "empty-normalized-agent shows error"
+
+# --- Test 9: Bad base refs fail before creating the worktree root ---
+working="$(setup_repo repo6)"
+bad_base_root="$tmp_root/bad-base-root"
+rc=0
+output="$(bash "$working/scripts/new-worktree.sh" --root "$bad_base_root" --agent codex --issue 128 --slug bad-base --base does-not-exist 2>&1)" || rc=$?
+assert_exit_code 1 "$rc" "bad-base exits 1"
+assert_output_contains "$output" "Base ref not found: does-not-exist" "bad-base shows error"
+assert_path_missing "$bad_base_root" "bad-base does not create root"
 
 echo ""
 echo "Results: $passed passed, $failed failed"

--- a/scripts/test-new-worktree.sh
+++ b/scripts/test-new-worktree.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Regression tests for scaffold/root/scripts/new-worktree.sh
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+helper_source="$repo_root/scaffold/root/scripts/new-worktree.sh"
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/new-worktree-test.XXXXXX")"
+tmp_root="$(cd "$tmp_root" && pwd -P)"
+
+cleanup() {
+  rm -rf "$tmp_root"
+}
+
+trap cleanup EXIT
+
+passed=0
+failed=0
+
+assert_exit_code() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [[ "$actual" -eq "$expected" ]]; then
+    echo "PASS: $label"
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $label (expected exit $expected, got $actual)" >&2
+    failed=$((failed + 1))
+  fi
+}
+
+assert_output_contains() {
+  local output="$1"
+  local expected_text="$2"
+  local label="$3"
+
+  if [[ "$output" == *"$expected_text"* ]]; then
+    echo "PASS: $label"
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $label - expected text not found: $expected_text" >&2
+    echo "  Actual output: $output" >&2
+    failed=$((failed + 1))
+  fi
+}
+
+assert_path_exists() {
+  local path="$1"
+  local label="$2"
+
+  if [[ -e "$path" ]]; then
+    echo "PASS: $label"
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $label - missing path: $path" >&2
+    failed=$((failed + 1))
+  fi
+}
+
+assert_path_under_tmp() {
+  local path="$1"
+  local label="$2"
+
+  case "$(cd "$(dirname "$path")" && pwd -P)/$(basename "$path")/" in
+    "$tmp_root/"*)
+      echo "PASS: $label"
+      passed=$((passed + 1))
+      ;;
+    *)
+      echo "FAIL: $label - path escaped temp root: $path" >&2
+      failed=$((failed + 1))
+      ;;
+  esac
+}
+
+setup_repo() {
+  local label="$1"
+  local origin="$tmp_root/${label}-origin.git"
+  local seed="$tmp_root/${label}-seed"
+  local working="$tmp_root/${label}-working"
+
+  git init --bare "$origin" >/dev/null
+  git -C "$origin" symbolic-ref HEAD refs/heads/main
+
+  git init -b main "$seed" >/dev/null
+  git -C "$seed" config user.name "Test User"
+  git -C "$seed" config user.email "test@example.com"
+  mkdir -p "$seed/scripts"
+  cp "$helper_source" "$seed/scripts/new-worktree.sh"
+  chmod +x "$seed/scripts/new-worktree.sh"
+  echo "seed" > "$seed/README.md"
+  git -C "$seed" add README.md scripts/new-worktree.sh
+  git -C "$seed" commit -m "seed" >/dev/null
+  git -C "$seed" remote add origin "$origin"
+  git -C "$seed" push -u origin main >/dev/null
+
+  git clone "$origin" "$working" >/dev/null
+  printf '%s\n' "$working"
+}
+
+run_new_worktree() {
+  local working="$1"
+  shift
+
+  bash "$working/scripts/new-worktree.sh" --root "$tmp_root/wt" "$@"
+}
+
+# --- Test 1: Create a new worktree with explicit slug ---
+working="$(setup_repo repo1)"
+rc=0
+output="$(run_new_worktree "$working" --agent codex --issue 123 --slug feature-slice 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "create-worktree exits 0"
+expected_path="$tmp_root/wt/codex-123-feature-slice"
+assert_path_exists "$expected_path" "create-worktree created target path"
+assert_path_under_tmp "$expected_path" "create-worktree stays inside temp root"
+branch_name="$(git -C "$expected_path" branch --show-current)"
+if [[ "$branch_name" == "codex/123-feature-slice" ]]; then
+  echo "PASS: create-worktree branch name"
+  passed=$((passed + 1))
+else
+  echo "FAIL: create-worktree branch name (got $branch_name)" >&2
+  failed=$((failed + 1))
+fi
+assert_output_contains "$output" "Created worktree:" "create-worktree reports creation"
+assert_output_contains "$output" "cd $expected_path" "create-worktree prints cd hint"
+assert_output_contains "$output" "codex" "create-worktree prints codex hint"
+
+# --- Test 2: Re-running the same command is idempotent ---
+rc=0
+output="$(run_new_worktree "$working" --agent codex --issue 123 --slug feature-slice 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "recreate-worktree exits 0"
+assert_output_contains "$output" "Worktree already exists:" "recreate-worktree reports existing path"
+assert_output_contains "$output" "$expected_path" "recreate-worktree prints existing path"
+
+# --- Test 3: Agent and slug values are normalized ---
+working="$(setup_repo repo2)"
+rc=0
+output="$(run_new_worktree "$working" --agent "Claude Code" --issue 124 --slug "Review Cleanup" 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "normalized-worktree exits 0"
+expected_path="$tmp_root/wt/claude-code-124-review-cleanup"
+assert_path_exists "$expected_path" "normalized-worktree created normalized path"
+assert_path_under_tmp "$expected_path" "normalized-worktree stays inside temp root"
+branch_name="$(git -C "$expected_path" branch --show-current)"
+if [[ "$branch_name" == "claude-code/124-review-cleanup" ]]; then
+  echo "PASS: normalized-worktree branch name"
+  passed=$((passed + 1))
+else
+  echo "FAIL: normalized-worktree branch name (got $branch_name)" >&2
+  failed=$((failed + 1))
+fi
+assert_output_contains "$output" "claude" "normalized-worktree prints claude hint"
+
+# --- Test 4: Gemini launch hint is supported ---
+working="$(setup_repo repo3)"
+rc=0
+output="$(run_new_worktree "$working" --agent gemini --issue 125 --slug docs-followup 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "gemini-worktree exits 0"
+assert_output_contains "$output" "gemini" "gemini-worktree prints gemini hint"
+
+# --- Test 5: Stale worktree metadata is pruned and recreated ---
+working="$(setup_repo repo4)"
+rc=0
+output="$(run_new_worktree "$working" --agent codex --issue 126 --slug stale-recreate 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "stale-worktree initial create exits 0"
+expected_path="$tmp_root/wt/codex-126-stale-recreate"
+assert_path_exists "$expected_path" "stale-worktree initial path exists"
+rm -rf "$expected_path"
+rc=0
+output="$(run_new_worktree "$working" --agent codex --issue 126 --slug stale-recreate 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "stale-worktree recreate exits 0"
+assert_output_contains "$output" "Created worktree:" "stale-worktree rerun recreates path"
+assert_path_exists "$expected_path" "stale-worktree recreated target path"
+
+# --- Test 6: Missing required args fail clearly ---
+working="$(setup_repo repo5)"
+rc=0
+output="$(run_new_worktree "$working" --agent codex 2>&1)" || rc=$?
+assert_exit_code 1 "$rc" "missing-issue exits 1"
+assert_output_contains "$output" "--issue is required" "missing-issue shows error"
+
+echo ""
+echo "Results: $passed passed, $failed failed"
+if [[ "$failed" -gt 0 ]]; then
+  exit 1
+fi
+echo "new-worktree.sh regression checks passed."

--- a/scripts/test-remove-worktree.sh
+++ b/scripts/test-remove-worktree.sh
@@ -172,6 +172,72 @@ assert_exit_code 1 "$rc" "remove-detached-delete-branch exits 1"
 assert_output_contains "$output" "--delete-branch requires a branch-backed worktree" "remove-detached-delete-branch shows precondition error"
 assert_path_exists "$worktree_path" "remove-detached-delete-branch preserves worktree"
 
+# --- Test 6: Remove a detached-HEAD worktree by path without deleting a branch ---
+working="$(setup_repo repo6)"
+worktree_path="$(create_detached_worktree "$working" "detached-cleanup-success")"
+rc=0
+output="$(cd "$working" && bash scripts/remove-worktree.sh --path "$worktree_path" 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "remove-detached-by-path exits 0"
+assert_output_contains "$output" "Removed worktree:" "remove-detached-by-path reports removal"
+assert_path_missing "$worktree_path" "remove-detached-by-path deleted target path"
+
+# --- Test 7: Ignore shared .venv .pth files that point outside the target worktree ---
+working="$(setup_repo repo7)"
+worktree_path="$(create_worktree "$working" "codex/126-unrelated-venv" "codex-126-unrelated-venv")"
+unrelated_path="$tmp_root/unrelated-editable/src"
+mkdir -p "$working/.venv/lib/python3.10/site-packages" "$unrelated_path"
+printf '%s\n' "$unrelated_path" > "$working/.venv/lib/python3.10/site-packages/editable_project.pth"
+rc=0
+output="$(cd "$working" && bash scripts/remove-worktree.sh --branch codex/126-unrelated-venv 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "remove-unrelated-venv exits 0"
+assert_path_missing "$worktree_path" "remove-unrelated-venv deleted target path"
+
+# --- Test 8: Force removal succeeds for a dirty disposable worktree ---
+working="$(setup_repo repo8)"
+worktree_path="$(create_worktree "$working" "codex/127-force-dirty" "codex-127-force-dirty")"
+echo "dirty" > "$worktree_path/untracked.txt"
+rc=0
+output="$(cd "$working" && bash scripts/remove-worktree.sh --branch codex/127-force-dirty --force 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "remove-force-dirty exits 0"
+assert_output_contains "$output" "Removed worktree:" "remove-force-dirty reports removal"
+assert_path_missing "$worktree_path" "remove-force-dirty deleted target path"
+
+# --- Test 9: Refuse when --branch and --path refer to different worktrees ---
+working="$(setup_repo repo9)"
+worktree_a="$(create_worktree "$working" "codex/128-mismatch-a" "codex-128-mismatch-a")"
+worktree_b="$(create_worktree "$working" "codex/128-mismatch-b" "codex-128-mismatch-b")"
+rc=0
+output="$(cd "$working" && bash scripts/remove-worktree.sh --branch codex/128-mismatch-a --path "$worktree_b" 2>&1)" || rc=$?
+assert_exit_code 1 "$rc" "remove-branch-path-mismatch exits 1"
+assert_output_contains "$output" "--branch and --path refer to different worktrees" "remove-branch-path-mismatch shows error"
+assert_path_exists "$worktree_a" "remove-branch-path-mismatch preserves branch worktree"
+assert_path_exists "$worktree_b" "remove-branch-path-mismatch preserves path worktree"
+
+# --- Test 10: Stale branch worktree records are pruned with a clear error ---
+working="$(setup_repo repo10)"
+worktree_path="$(create_worktree "$working" "codex/129-stale-record" "codex-129-stale-record")"
+rm -rf "$worktree_path"
+rc=0
+output="$(cd "$working" && bash scripts/remove-worktree.sh --branch codex/129-stale-record 2>&1)" || rc=$?
+assert_exit_code 1 "$rc" "remove-stale-record exits 1"
+assert_output_contains "$output" "Stale metadata was pruned" "remove-stale-record shows prune message"
+if git -C "$working" show-ref --verify --quiet refs/heads/codex/129-stale-record; then
+  echo "PASS: remove-stale-record preserves branch"
+  passed=$((passed + 1))
+else
+  echo "FAIL: remove-stale-record preserves branch" >&2
+  failed=$((failed + 1))
+fi
+
+# --- Test 11: Bad --path values fail before any safety checks use the cwd ---
+working="$(setup_repo repo11)"
+missing_path="$tmp_root/wt/missing-worktree"
+rc=0
+output="$(cd "$working" && bash scripts/remove-worktree.sh --path "$missing_path" 2>&1)" || rc=$?
+assert_exit_code 1 "$rc" "remove-missing-path exits 1"
+assert_output_contains "$output" "Worktree path does not exist: $missing_path" "remove-missing-path shows error"
+assert_path_exists "$working" "remove-missing-path preserves checkout"
+
 echo ""
 echo "Results: $passed passed, $failed failed"
 if [[ "$failed" -gt 0 ]]; then

--- a/scripts/test-remove-worktree.sh
+++ b/scripts/test-remove-worktree.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Regression tests for scaffold/root/scripts/remove-worktree.sh
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+helper_source="$repo_root/scaffold/root/scripts/remove-worktree.sh"
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/remove-worktree-test.XXXXXX")"
+tmp_root="$(cd "$tmp_root" && pwd -P)"
+
+cleanup() {
+  rm -rf "$tmp_root"
+}
+
+trap cleanup EXIT
+
+passed=0
+failed=0
+
+assert_exit_code() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [[ "$actual" -eq "$expected" ]]; then
+    echo "PASS: $label"
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $label (expected exit $expected, got $actual)" >&2
+    failed=$((failed + 1))
+  fi
+}
+
+assert_output_contains() {
+  local output="$1"
+  local expected_text="$2"
+  local label="$3"
+
+  if [[ "$output" == *"$expected_text"* ]]; then
+    echo "PASS: $label"
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $label - expected text not found: $expected_text" >&2
+    echo "  Actual output: $output" >&2
+    failed=$((failed + 1))
+  fi
+}
+
+assert_path_exists() {
+  local path="$1"
+  local label="$2"
+
+  if [[ -e "$path" ]]; then
+    echo "PASS: $label"
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $label - missing path: $path" >&2
+    failed=$((failed + 1))
+  fi
+}
+
+assert_path_missing() {
+  local path="$1"
+  local label="$2"
+
+  if [[ ! -e "$path" ]]; then
+    echo "PASS: $label"
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $label - unexpected path still exists: $path" >&2
+    failed=$((failed + 1))
+  fi
+}
+
+setup_repo() {
+  local label="$1"
+  local origin="$tmp_root/${label}-origin.git"
+  local seed="$tmp_root/${label}-seed"
+  local working="$tmp_root/${label}-working"
+
+  git init --bare "$origin" >/dev/null
+  git -C "$origin" symbolic-ref HEAD refs/heads/main
+
+  git init -b main "$seed" >/dev/null
+  git -C "$seed" config user.name "Test User"
+  git -C "$seed" config user.email "test@example.com"
+  mkdir -p "$seed/scripts"
+  cp "$helper_source" "$seed/scripts/remove-worktree.sh"
+  chmod +x "$seed/scripts/remove-worktree.sh"
+  echo "seed" > "$seed/README.md"
+  git -C "$seed" add README.md scripts/remove-worktree.sh
+  git -C "$seed" commit -m "seed" >/dev/null
+  git -C "$seed" remote add origin "$origin"
+  git -C "$seed" push -u origin main >/dev/null
+
+  git clone "$origin" "$working" >/dev/null
+  printf '%s\n' "$working"
+}
+
+create_worktree() {
+  local working="$1"
+  local branch_name="$2"
+  local worktree_name="$3"
+  local worktree_path="$tmp_root/wt/$worktree_name"
+
+  mkdir -p "$(dirname "$worktree_path")"
+  git -C "$working" worktree add -b "$branch_name" "$worktree_path" main >/dev/null
+  printf '%s\n' "$worktree_path"
+}
+
+create_detached_worktree() {
+  local working="$1"
+  local worktree_name="$2"
+  local worktree_path="$tmp_root/wt/$worktree_name"
+
+  mkdir -p "$(dirname "$worktree_path")"
+  git -C "$working" worktree add --detach "$worktree_path" main >/dev/null
+  printf '%s\n' "$worktree_path"
+}
+
+# --- Test 1: Refuse removal when shared .venv still points into the worktree ---
+working="$(setup_repo repo1)"
+worktree_path="$(create_worktree "$working" "codex/123-feature-slice" "codex-123-feature-slice")"
+mkdir -p "$working/.venv/lib/python3.10/site-packages" "$worktree_path/src"
+printf '%s\n' "$worktree_path/src" > "$working/.venv/lib/python3.10/site-packages/editable_project.pth"
+rc=0
+output="$(cd "$working" && bash scripts/remove-worktree.sh --branch codex/123-feature-slice 2>&1)" || rc=$?
+assert_exit_code 1 "$rc" "remove-bound-worktree exits 1"
+assert_output_contains "$output" "Refusing to remove worktree while the shared .venv editable install points inside it" "remove-bound-worktree shows binding error"
+assert_output_contains "$output" "Reinstall the editable package from the main checkout first" "remove-bound-worktree shows generic remediation"
+assert_path_exists "$worktree_path" "remove-bound-worktree preserves worktree"
+
+# --- Test 2: Remove a branch-backed worktree from a safe cwd without .venv ---
+working="$(setup_repo repo2)"
+worktree_path="$(create_worktree "$working" "codex/124-review-cleanup" "codex-124-review-cleanup")"
+rc=0
+output="$(cd "$working" && bash scripts/remove-worktree.sh --branch codex/124-review-cleanup --delete-branch 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "remove-worktree exits 0"
+assert_path_missing "$worktree_path" "remove-worktree deleted target path"
+if git -C "$working" show-ref --verify --quiet refs/heads/codex/124-review-cleanup; then
+  echo "FAIL: remove-worktree deleted branch" >&2
+  failed=$((failed + 1))
+else
+  echo "PASS: remove-worktree deleted branch"
+  passed=$((passed + 1))
+fi
+assert_output_contains "$output" "Removed worktree:" "remove-worktree reports removal"
+
+# --- Test 3: Refuse to remove the active cwd ---
+working="$(setup_repo repo3)"
+worktree_path="$(create_worktree "$working" "codex/125-active-cwd" "codex-125-active-cwd")"
+rc=0
+output="$(cd "$worktree_path" && bash "$working/scripts/remove-worktree.sh" --branch codex/125-active-cwd 2>&1)" || rc=$?
+assert_exit_code 1 "$rc" "remove-active-cwd exits 1"
+assert_output_contains "$output" "Refusing to remove worktree containing current working directory" "remove-active-cwd shows safety error"
+assert_path_exists "$worktree_path" "remove-active-cwd preserves worktree"
+
+# --- Test 4: Refuse to remove the primary checkout ---
+working="$(setup_repo repo4)"
+rc=0
+output="$(cd "$working" && bash scripts/remove-worktree.sh --branch main 2>&1)" || rc=$?
+assert_exit_code 1 "$rc" "remove-primary exits 1"
+assert_output_contains "$output" "Refusing to remove primary checkout" "remove-primary shows safety error"
+assert_path_exists "$working" "remove-primary preserves main checkout"
+
+# --- Test 5: Refuse --delete-branch before removing a detached-HEAD worktree ---
+working="$(setup_repo repo5)"
+worktree_path="$(create_detached_worktree "$working" "detached-cleanup-check")"
+rc=0
+output="$(cd "$working" && bash scripts/remove-worktree.sh --path "$worktree_path" --delete-branch 2>&1)" || rc=$?
+assert_exit_code 1 "$rc" "remove-detached-delete-branch exits 1"
+assert_output_contains "$output" "--delete-branch requires a branch-backed worktree" "remove-detached-delete-branch shows precondition error"
+assert_path_exists "$worktree_path" "remove-detached-delete-branch preserves worktree"
+
+echo ""
+echo "Results: $passed passed, $failed failed"
+if [[ "$failed" -gt 0 ]]; then
+  exit 1
+fi
+echo "remove-worktree.sh regression checks passed."

--- a/scripts/test-worktree-helper-sync.sh
+++ b/scripts/test-worktree-helper-sync.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Regression tests for generated-project worktree helper seeding and sync.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/worktree-helper-sync-test.XXXXXX")"
+tmp_root="$(cd "$tmp_root" && pwd -P)"
+
+cleanup() {
+  rm -rf "$tmp_root"
+}
+
+trap cleanup EXIT
+
+passed=0
+failed=0
+
+assert_exit_code() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [[ "$actual" -eq "$expected" ]]; then
+    echo "PASS: $label"
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $label (expected exit $expected, got $actual)" >&2
+    failed=$((failed + 1))
+  fi
+}
+
+assert_output_contains() {
+  local output="$1"
+  local expected_text="$2"
+  local label="$3"
+
+  if [[ "$output" == *"$expected_text"* ]]; then
+    echo "PASS: $label"
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $label - expected text not found: $expected_text" >&2
+    echo "  Actual output: $output" >&2
+    failed=$((failed + 1))
+  fi
+}
+
+assert_file_contains() {
+  local path="$1"
+  local expected_text="$2"
+  local label="$3"
+
+  if [[ -f "$path" ]] && grep -Fq "$expected_text" "$path"; then
+    echo "PASS: $label"
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $label - expected text not found in $path: $expected_text" >&2
+    failed=$((failed + 1))
+  fi
+}
+
+assert_path_exists() {
+  local path="$1"
+  local label="$2"
+
+  if [[ -e "$path" ]]; then
+    echo "PASS: $label"
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $label - missing path: $path" >&2
+    failed=$((failed + 1))
+  fi
+}
+
+assert_executable() {
+  local path="$1"
+  local label="$2"
+
+  if [[ -x "$path" ]]; then
+    echo "PASS: $label"
+    passed=$((passed + 1))
+  else
+    echo "FAIL: $label - not executable: $path" >&2
+    failed=$((failed + 1))
+  fi
+}
+
+setup_empty_repo() {
+  local label="$1"
+  local repo="$tmp_root/$label"
+
+  mkdir -p "$repo"
+  git -C "$repo" init -b main >/dev/null
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" config user.email "test@example.com"
+  printf '%s\n' "$repo"
+}
+
+run_new_project() {
+  local target="$1"
+
+  bash "$repo_root/scripts/new-project.sh" "Example App" "$target"
+}
+
+run_update_project() {
+  local target="$1"
+  shift
+
+  bash "$repo_root/scripts/update-project.sh" "$target" "$@"
+}
+
+# --- Test 1: new-project seeds executable managed helpers and the runbook ---
+target="$(setup_empty_repo new-project-target)"
+rc=0
+output="$(run_new_project "$target" 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "new-project exits 0"
+assert_path_exists "$target/scripts/new-worktree.sh" "new-project creates new-worktree helper"
+assert_path_exists "$target/scripts/remove-worktree.sh" "new-project creates remove-worktree helper"
+assert_path_exists "$target/docs/runbooks/parallel-agent-worktrees.md" "new-project creates worktree runbook"
+assert_executable "$target/scripts/new-worktree.sh" "new-project makes new-worktree executable"
+assert_executable "$target/scripts/remove-worktree.sh" "new-project makes remove-worktree executable"
+assert_file_contains "$target/scripts/new-worktree.sh" "# agent-vault-managed: helper-script; file=new-worktree.sh" "new-project seeds new-worktree marker"
+assert_file_contains "$target/scripts/remove-worktree.sh" "# agent-vault-managed: helper-script; file=remove-worktree.sh" "new-project seeds remove-worktree marker"
+
+# --- Test 2: update-project creates missing helpers in existing vaults ---
+target="$(setup_empty_repo update-missing-target)"
+run_new_project "$target" >/dev/null
+rm "$target/scripts/new-worktree.sh" "$target/scripts/remove-worktree.sh"
+rc=0
+output="$(run_update_project "$target" 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "update-project missing-helper exits 0"
+assert_output_contains "$output" "Created: scripts/new-worktree.sh" "update-project reports new-worktree creation"
+assert_output_contains "$output" "Created: scripts/remove-worktree.sh" "update-project reports remove-worktree creation"
+assert_executable "$target/scripts/new-worktree.sh" "update-project makes new-worktree executable"
+assert_executable "$target/scripts/remove-worktree.sh" "update-project makes remove-worktree executable"
+
+# --- Test 3: update-project skips unmanaged helper scripts by default ---
+target="$(setup_empty_repo unmanaged-skip-target)"
+run_new_project "$target" >/dev/null
+printf '%s\n' '#!/usr/bin/env bash' 'echo custom helper' > "$target/scripts/new-worktree.sh"
+chmod +x "$target/scripts/new-worktree.sh"
+rc=0
+output="$(run_update_project "$target" 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "update-project unmanaged-helper exits 0"
+assert_output_contains "$output" "Skip: scripts/new-worktree.sh (unmanaged root helper script; use --migrate-root-scripts to replace)" "update-project reports unmanaged helper skip"
+assert_file_contains "$target/scripts/new-worktree.sh" "echo custom helper" "update-project preserves unmanaged helper"
+
+# --- Test 4: --migrate-root-scripts backs up and replaces unmanaged helpers ---
+target="$(setup_empty_repo unmanaged-migrate-target)"
+run_new_project "$target" >/dev/null
+printf '%s\n' '#!/usr/bin/env bash' 'echo custom helper' > "$target/scripts/new-worktree.sh"
+chmod +x "$target/scripts/new-worktree.sh"
+rc=0
+output="$(run_update_project "$target" --migrate-root-scripts 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "update-project migrate-helper exits 0"
+assert_output_contains "$output" "Migrating: scripts/new-worktree.sh (unmanaged -> managed helper script)" "update-project reports helper migration"
+assert_file_contains "$target/scripts/new-worktree.sh" "# agent-vault-managed: helper-script; file=new-worktree.sh" "update-project replaces unmanaged helper with managed helper"
+assert_executable "$target/scripts/new-worktree.sh" "update-project migrated helper executable"
+backup_count="$(find "$target/agent-vault/context/updates" -path '*/scripts/new-worktree.sh' -type f | wc -l | tr -d ' ')"
+if [[ "$backup_count" -ge 1 ]]; then
+  echo "PASS: update-project backs up migrated helper"
+  passed=$((passed + 1))
+else
+  echo "FAIL: update-project backs up migrated helper" >&2
+  failed=$((failed + 1))
+fi
+
+# --- Test 5: update-project refreshes managed helpers and fixes executable bit ---
+target="$(setup_empty_repo managed-refresh-target)"
+run_new_project "$target" >/dev/null
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' '# agent-vault-managed: helper-script; file=new-worktree.sh'
+  printf '%s\n' 'echo stale managed helper'
+} > "$target/scripts/new-worktree.sh"
+chmod -x "$target/scripts/new-worktree.sh"
+rc=0
+output="$(run_update_project "$target" 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "update-project managed-refresh exits 0"
+assert_output_contains "$output" "Updated: scripts/new-worktree.sh" "update-project reports managed helper update"
+assert_file_contains "$target/scripts/new-worktree.sh" "Create or reuse one issue-scoped worktree" "update-project refreshes managed helper content"
+assert_executable "$target/scripts/new-worktree.sh" "update-project fixes managed helper executable bit"
+
+# --- Test 6: runbook is seed-only after creation ---
+target="$(setup_empty_repo runbook-seed-target)"
+run_new_project "$target" >/dev/null
+printf '%s\n' '# Local Worktree Runbook' > "$target/docs/runbooks/parallel-agent-worktrees.md"
+rc=0
+output="$(run_update_project "$target" 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "update-project runbook-seed exits 0"
+assert_file_contains "$target/docs/runbooks/parallel-agent-worktrees.md" "# Local Worktree Runbook" "update-project preserves existing runbook"
+
+echo ""
+echo "Results: $passed passed, $failed failed"
+if [[ "$failed" -gt 0 ]]; then
+  exit 1
+fi
+echo "worktree helper sync regression checks passed."

--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -7,12 +7,13 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "$script_dir/lib/tracked-hooks.sh"
 
 usage() {
-  echo "Usage: $0 <repo-path> [--dry-run] [--migrate-root] [--sync-templates] [--sync-coding-standards]"
+  echo "Usage: $0 <repo-path> [--dry-run] [--migrate-root] [--migrate-root-scripts] [--sync-templates] [--sync-coding-standards]"
   echo "Example: $0 ~/workspaces/harrier --dry-run --sync-templates --sync-coding-standards"
   echo ""
   echo "Options:"
   echo "  --dry-run       Show what would change without writing files"
   echo "  --migrate-root  Replace unmanaged root wrappers with managed versions (backs up originals)"
+  echo "  --migrate-root-scripts  Replace unmanaged root helper scripts with managed versions (backs up originals)"
   echo "  --sync-templates  Refresh project-local agent-vault/Templates/ from scaffold (backs up existing files); policy-critical templates may sync on normal updates"
   echo "  --sync-coding-standards  Replace agent-vault/coding-standards.md from scaffold (backs up existing file)"
 }
@@ -48,6 +49,8 @@ MANAGED_GITIGNORE_BLOCKS=(
 ROOT_AGENTS_MARKER="<!-- agent-vault-managed: root-wrapper; file=AGENTS.md -->"
 ROOT_CLAUDE_MARKER="<!-- agent-vault-managed: root-wrapper; file=CLAUDE.md -->"
 ROOT_GEMINI_MARKER="<!-- agent-vault-managed: root-wrapper; file=GEMINI.md -->"
+NEW_WORKTREE_HELPER_MARKER="# agent-vault-managed: helper-script; file=new-worktree.sh"
+REMOVE_WORKTREE_HELPER_MARKER="# agent-vault-managed: helper-script; file=remove-worktree.sh"
 POLICY_TEMPLATE_REL_PATHS=(
   "Decision Record.md"
 )
@@ -55,6 +58,7 @@ POLICY_TEMPLATE_REL_PATHS=(
 repo_path_input=""
 dry_run="false"
 migrate_root="false"
+migrate_root_scripts="false"
 sync_templates="false"
 sync_coding_standards="false"
 
@@ -65,6 +69,9 @@ for arg in "$@"; do
       ;;
     --migrate-root)
       migrate_root="true"
+      ;;
+    --migrate-root-scripts)
+      migrate_root_scripts="true"
       ;;
     --sync-templates)
       sync_templates="true"
@@ -121,6 +128,9 @@ for required in \
   "$root_scaffold_dir/GEMINI.md" \
   "$root_scaffold_dir/.github/pull_request_template.md" \
   "$root_scaffold_dir/docs/design.md" \
+  "$root_scaffold_dir/docs/runbooks/parallel-agent-worktrees.md" \
+  "$root_scaffold_dir/scripts/new-worktree.sh" \
+  "$root_scaffold_dir/scripts/remove-worktree.sh" \
   "$vault_scaffold_dir/AGENTS.md" \
   "$vault_scaffold_dir/CLAUDE.md" \
   "$vault_scaffold_dir/GEMINI.md" \
@@ -588,6 +598,14 @@ is_managed_root_wrapper() {
   has_exact_line "$file_path" "$marker"
 }
 
+is_managed_helper_script() {
+  local file_path="$1"
+  local marker="$2"
+
+  [[ -f "$file_path" ]] || return 1
+  has_exact_line "$file_path" "$marker"
+}
+
 sync_managed_file() {
   local src="$1"
   local dest="$2"
@@ -640,6 +658,17 @@ sync_managed_file() {
   fi
 
   updated=$((updated + 1))
+}
+
+sync_managed_executable_file() {
+  local src="$1"
+  local dest="$2"
+
+  sync_managed_file "$src" "$dest"
+
+  if [[ "$dry_run" != "true" && -f "$dest" ]]; then
+    chmod +x "$dest"
+  fi
 }
 
 seed_if_missing() {
@@ -774,6 +803,40 @@ sync_root_wrapper_if_managed() {
   skipped=$((skipped + 1))
 }
 
+sync_root_helper_script_if_managed() {
+  local src="$1"
+  local dest="$2"
+  local marker="$3"
+  local rel
+
+  rel="$(repo_relative_path "$dest")"
+
+  if [[ -L "$dest" ]]; then
+    echo "Skip: $rel (symlink files are not auto-managed)"
+    skipped=$((skipped + 1))
+    return
+  fi
+
+  if [[ ! -e "$dest" ]]; then
+    sync_managed_executable_file "$src" "$dest"
+    return
+  fi
+
+  if is_managed_helper_script "$dest" "$marker"; then
+    sync_managed_executable_file "$src" "$dest"
+    return
+  fi
+
+  if [[ "$migrate_root_scripts" == "true" ]]; then
+    echo "Migrating: $rel (unmanaged -> managed helper script)"
+    sync_managed_executable_file "$src" "$dest"
+    return
+  fi
+
+  echo "Skip: $rel (unmanaged root helper script; use --migrate-root-scripts to replace)"
+  skipped=$((skipped + 1))
+}
+
 ensure_managed_gitignore_entries() {
   local repo_root="$1"
   local gitignore_path="$repo_root/.gitignore"
@@ -838,6 +901,9 @@ sync_root_wrapper_if_managed "$root_scaffold_dir/CLAUDE.md" "$canonical_repo_pat
 sync_root_wrapper_if_managed "$root_scaffold_dir/GEMINI.md" "$canonical_repo_path/GEMINI.md" "$ROOT_GEMINI_MARKER"
 seed_if_missing "$root_scaffold_dir/.github/pull_request_template.md" "$canonical_repo_path/.github/pull_request_template.md"
 seed_if_missing "$root_scaffold_dir/docs/design.md" "$canonical_repo_path/docs/design.md"
+seed_if_missing "$root_scaffold_dir/docs/runbooks/parallel-agent-worktrees.md" "$canonical_repo_path/docs/runbooks/parallel-agent-worktrees.md"
+sync_root_helper_script_if_managed "$root_scaffold_dir/scripts/new-worktree.sh" "$canonical_repo_path/scripts/new-worktree.sh" "$NEW_WORKTREE_HELPER_MARKER"
+sync_root_helper_script_if_managed "$root_scaffold_dir/scripts/remove-worktree.sh" "$canonical_repo_path/scripts/remove-worktree.sh" "$REMOVE_WORKTREE_HELPER_MARKER"
 sync_project_owned_file_if_requested "$vault_scaffold_dir/coding-standards.md" "$project_dir/coding-standards.md" "--sync-coding-standards" "$sync_coding_standards"
 seed_if_missing "$vault_scaffold_dir/project-context.md" "$project_dir/project-context.md"
 seed_if_missing "$vault_scaffold_dir/project-commands.md" "$project_dir/project-commands.md"


### PR DESCRIPTION
> 🤖 Prepared by Codex GPT-5 · via Codex CLI

## Summary
- Problem: Generated projects do not have a reusable, template-managed workflow for creating and safely removing issue-scoped Git worktrees for parallel agent work.
- Approach: Port the proven downstream worktree helper workflow into the template as sanitized managed root helper scripts, with scaffold sync, migration, docs, and regression coverage.
- Outcome: New projects receive worktree create/remove helpers and a runbook; existing projects can receive or migrate the helpers via `update-project.sh`.

Closes #88.

## Changes
- `scaffold/root/scripts/new-worktree.sh`: added a managed helper to create or reuse one issue-scoped worktree per writing agent, with Codex/Claude/Gemini launch hints and explicit sibling-root defaults.
- `scaffold/root/scripts/remove-worktree.sh`: added a managed cleanup helper with safe-cwd, primary-checkout, detached-worktree, branch-delete, force-remove, and generic `.venv` editable-install guardrails.
- `scripts/new-project.sh`: seeds the new helper scripts and worktree runbook for newly generated projects, preserving executable permissions.
- `scripts/update-project.sh`: syncs managed helper scripts, seeds missing helpers, skips unmanaged helpers by default, and adds `--migrate-root-scripts` for opt-in migration with backups.
- `scaffold/root/docs/runbooks/parallel-agent-worktrees.md`: documents the one-issue/one-branch/one-worktree/one-writing-agent workflow, including sandbox guidance to run setup from the original checkout but launch writing agents from inside the generated worktree.
- `scaffold/agent-vault/project-commands.md`: adds generic Codex, Claude, and Gemini worktree command examples for new projects.
- `.github/workflows/scaffold-regression-checks.yml`: extends path filters and CI jobs for the new helper and sync tests.
- `scripts/test-new-worktree.sh`, `scripts/test-remove-worktree.sh`, `scripts/test-worktree-helper-sync.sh`: adds regression coverage for helper behavior and scaffold sync/migration behavior.
- `README.md`: documents helper script template locations, existing-repo migration behavior, and the new regression checks.

## Verification Loop
- Build / package: Not applicable; shell/Markdown scaffold change.
- Typecheck / static analysis: `bash -n scaffold/root/scripts/new-worktree.sh scaffold/root/scripts/remove-worktree.sh scripts/new-project.sh scripts/update-project.sh scripts/test-new-worktree.sh scripts/test-remove-worktree.sh scripts/test-worktree-helper-sync.sh` - passed.
- Lint / format validation: `git diff --cached --check` - passed before commit.
- Tests / coverage: `bash scripts/check-policy-mirrors.sh` - passed.
- Tests / coverage: `bash scripts/test-new-worktree.sh` - passed, 24 assertions.
- Tests / coverage: `bash scripts/test-remove-worktree.sh` - passed, 17 assertions.
- Tests / coverage: `bash scripts/test-worktree-helper-sync.sh` - passed, 27 assertions.
- Tests / coverage: `bash scripts/test-gitignore-management.sh` - passed.
- Tests / coverage: `bash scripts/test-coding-standards-sync.sh` - passed.
- Tests / coverage: `bash scripts/test-decision-template-sync.sh` - passed.
- Tests / coverage: `bash scripts/test-session-metadata-hook.sh` - passed.
- Security / secrets / workflow checks: searched for private downstream project identifiers and local-path leakage; no project-specific references were added.
- Diff review: reviewed staged diff, file modes, helper marker placement, scaffold sync paths, and CI path filters.
- Not run: no package build or language-specific test suite exists for this shell/Markdown scaffold repository.

## Risks and Rollback
- Risk: Existing projects with custom `scripts/new-worktree.sh` or `scripts/remove-worktree.sh` could be surprised by template helpers.
- Mitigation: `update-project.sh` skips unmanaged helper scripts by default and only replaces them when `--migrate-root-scripts` is explicitly provided.
- Risk: Agent clients may prompt when a session launched from the main checkout edits a sibling worktree.
- Mitigation: The runbook documents launching writing agents from inside the generated worktree and using the main checkout for setup/cleanup.
- Rollback: Revert this commit to remove the helpers, sync behavior, docs, and tests. Generated projects that already received the helpers can delete the two root scripts and runbook if desired.

## Docs Consistency
- `docs/design.md`: No impact; this changes repository scaffolding and operational helper scripts, not the generated project architecture/design model.
- `README.md`: Updated to describe generated worktree helpers, update-project migration behavior, and new regression checks.

## Review Feedback Mapping
| # | Finding | Status | Evidence / Rationale |
|---|---------|--------|----------------------|
| 1 | Pin exact shell-script marker form | Resolved | `76717d6`; helper scripts use `# agent-vault-managed: helper-script; file=...` immediately after the shebang. |
| 2 | Executable bit handling | Resolved | `76717d6`; `new-project.sh` and `update-project.sh` explicitly `chmod +x` helper scripts. |
| 3 | CI path filters | Resolved | `76717d6`; scaffold regression workflow watches root helper/runbook paths and runs new tests. |
| 4 | Required-file preflight lists | Resolved | `76717d6`; both scaffold scripts validate helper/runbook sources. |
| 5 | Test worktree root safety | Resolved | `76717d6`; helper tests pass explicit temp-local `--root` and assert paths remain in the temp sandbox. |
| 6 | Migration flag parity | Resolved | `76717d6`; added `--migrate-root-scripts`. |
| 7 | Editable-install guard no-op behavior | Resolved | `76717d6`; guard no-ops without `.venv` or matching `.pth` entries and blocks only actual target-worktree bindings. |
| 8 | Multi-agent examples | Resolved | `76717d6`; docs and generated project commands include Codex, Claude, and Gemini examples. |
| 9 | Sandbox-permissions runbook guidance | Resolved | `76717d6`; runbook documents setup from original checkout, writing from inside the worktree, cleanup from a safe cwd. |

## Follow-Ups
- [x] None