### PR TITLE
Tighten PR feedback retrieval policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,6 +345,10 @@ headers such as `Link: rel="next"` until no next page remains. Fetching only
 the first page is not sufficient on active PRs.
 
 ### Response Coverage
+- In this section, an actionable finding is any finding that requests or
+  implies a code, documentation, test, or policy change, including `Optional`
+  findings. Pure praise, acknowledgement, or background context does not
+  require a status mapping.
 - Address every actionable finding from every retrieved feedback surface; do
   not collapse multiple findings into one vague bullet.
 - If the same issue appears in multiple places, it may be fixed once, but the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,9 +324,40 @@ If the platform or API blocks the intended formal review state (e.g., permission
 ## Responding to Review Feedback
 When asked to address review feedback in a PR comment, use a complete, itemized response.
 
+### Feedback Retrieval Checklist
+Before claiming that all PR feedback was reviewed or addressed, inspect every
+available feedback surface:
+- Top-level PR review bodies.
+- PR conversation comments.
+- Inline PR review comments and review threads.
+
+For GitHub PRs, use retrieval that covers all pages of each surface. Equivalent
+tools are acceptable, but the retrieval must cover these REST API surfaces:
+- Top-level reviews: `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews`
+  (for example, `gh api --paginate repos/OWNER/REPO/pulls/NUMBER/reviews`).
+- Inline review comments: `GET /repos/{owner}/{repo}/pulls/{pull_number}/comments`
+  (for example, `gh api --paginate repos/OWNER/REPO/pulls/NUMBER/comments`).
+- PR conversation comments: `GET /repos/{owner}/{repo}/issues/{issue_number}/comments`
+  (for example, `gh api --paginate repos/OWNER/REPO/issues/NUMBER/comments`).
+
+When using raw REST calls instead of `gh api --paginate`, follow pagination
+headers such as `Link: rel="next"` until no next page remains. Fetching only
+the first page is not sufficient on active PRs.
+
+### Response Coverage
+- Address every actionable finding from every retrieved feedback surface; do
+  not collapse multiple findings into one vague bullet.
+- If the same issue appears in multiple places, it may be fixed once, but the
+  response must explicitly acknowledge the duplicate surfaces or state that
+  duplicate findings are grouped.
+- Top-level feedback-response comments may reference inline findings by
+  `path:line`, GitHub links, or equivalent anchors. This is allowed for
+  feedback responses and does not override the prohibition on imitating inline
+  review comments inside top-level review bodies.
+
 ### Required Coverage
-- Address every finding from the review being responded to; do not collapse multiple findings into one vague bullet.
-- For each finding, mark one status: `Resolved`, `Partially Resolved`, or `Not Changed`.
+- For each actionable finding identified by the retrieval checklist, mark one
+  status: `Resolved`, `Partially Resolved`, or `Not Changed`.
 - If a finding is `Partially Resolved` or `Not Changed`, explain exactly what remains and why.
 
 ### Evidence Requirements

--- a/scaffold/agent-vault/AGENTS.md
+++ b/scaffold/agent-vault/AGENTS.md
@@ -12,6 +12,9 @@
 
 ## PR Feedback Response
 - When posting a PR comment that addresses reviewer feedback, follow `agent-vault/review-policy.md` under `Responding to Review Feedback`.
+- When asked to review, summarize, respond to, or address all PR feedback, use
+  the feedback retrieval checklist in `agent-vault/review-policy.md` before
+  claiming all feedback was covered.
 - Map every finding to a status (`Resolved`, `Partially Resolved`, or `Not Changed`) with concrete evidence.
 - If pushing back, explain technical rationale and risk/tradeoff explicitly.
 

--- a/scaffold/agent-vault/review-policy.md
+++ b/scaffold/agent-vault/review-policy.md
@@ -309,6 +309,10 @@ headers such as `Link: rel="next"` until no next page remains. Fetching only
 the first page is not sufficient on active PRs.
 
 ### Response Coverage
+- In this section, an actionable finding is any finding that requests or
+  implies a code, documentation, test, or policy change, including `Optional`
+  findings. Pure praise, acknowledgement, or background context does not
+  require a status mapping.
 - Address every actionable finding from every retrieved feedback surface; do
   not collapse multiple findings into one vague bullet.
 - If the same issue appears in multiple places, it may be fixed once, but the

--- a/scaffold/agent-vault/review-policy.md
+++ b/scaffold/agent-vault/review-policy.md
@@ -288,9 +288,40 @@ If the platform or API blocks the intended formal review state (e.g., permission
 ## Responding to Review Feedback
 When asked to address review feedback in a PR comment, use a complete, itemized response.
 
+### Feedback Retrieval Checklist
+Before claiming that all PR feedback was reviewed or addressed, inspect every
+available feedback surface:
+- Top-level PR review bodies.
+- PR conversation comments.
+- Inline PR review comments and review threads.
+
+For GitHub PRs, use retrieval that covers all pages of each surface. Equivalent
+tools are acceptable, but the retrieval must cover these REST API surfaces:
+- Top-level reviews: `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews`
+  (for example, `gh api --paginate repos/OWNER/REPO/pulls/NUMBER/reviews`).
+- Inline review comments: `GET /repos/{owner}/{repo}/pulls/{pull_number}/comments`
+  (for example, `gh api --paginate repos/OWNER/REPO/pulls/NUMBER/comments`).
+- PR conversation comments: `GET /repos/{owner}/{repo}/issues/{issue_number}/comments`
+  (for example, `gh api --paginate repos/OWNER/REPO/issues/NUMBER/comments`).
+
+When using raw REST calls instead of `gh api --paginate`, follow pagination
+headers such as `Link: rel="next"` until no next page remains. Fetching only
+the first page is not sufficient on active PRs.
+
+### Response Coverage
+- Address every actionable finding from every retrieved feedback surface; do
+  not collapse multiple findings into one vague bullet.
+- If the same issue appears in multiple places, it may be fixed once, but the
+  response must explicitly acknowledge the duplicate surfaces or state that
+  duplicate findings are grouped.
+- Top-level feedback-response comments may reference inline findings by
+  `path:line`, GitHub links, or equivalent anchors. This is allowed for
+  feedback responses and does not override the prohibition on imitating inline
+  review comments inside top-level review bodies.
+
 ### Required Coverage
-- Address every finding from the review being responded to; do not collapse multiple findings into one vague bullet.
-- For each finding, mark one status: `Resolved`, `Partially Resolved`, or `Not Changed`.
+- For each actionable finding identified by the retrieval checklist, mark one
+  status: `Resolved`, `Partially Resolved`, or `Not Changed`.
 - If a finding is `Partially Resolved` or `Not Changed`, explain exactly what remains and why.
 
 ### Evidence Requirements

--- a/scaffold/agent-vault/shared-rules.md
+++ b/scaffold/agent-vault/shared-rules.md
@@ -7,6 +7,9 @@
 
 ## PR Feedback Response
 - When posting a PR comment that addresses reviewer feedback, follow `agent-vault/review-policy.md` under `Responding to Review Feedback`.
+- When asked to review, summarize, respond to, or address all PR feedback, use
+  the feedback retrieval checklist in `agent-vault/review-policy.md` before
+  claiming all feedback was covered.
 - Map every finding to a status (`Resolved`, `Partially Resolved`, or `Not Changed`) with concrete evidence.
 - If pushing back, explain technical rationale and risk/tradeoff explicitly.
 

--- a/scaffold/root/AGENTS.md
+++ b/scaffold/root/AGENTS.md
@@ -343,6 +343,10 @@ headers such as `Link: rel="next"` until no next page remains. Fetching only
 the first page is not sufficient on active PRs.
 
 ### Response Coverage
+- In this section, an actionable finding is any finding that requests or
+  implies a code, documentation, test, or policy change, including `Optional`
+  findings. Pure praise, acknowledgement, or background context does not
+  require a status mapping.
 - Address every actionable finding from every retrieved feedback surface; do
   not collapse multiple findings into one vague bullet.
 - If the same issue appears in multiple places, it may be fixed once, but the

--- a/scaffold/root/AGENTS.md
+++ b/scaffold/root/AGENTS.md
@@ -322,9 +322,40 @@ If the platform or API blocks the intended formal review state (e.g., permission
 ## Responding to Review Feedback
 When asked to address review feedback in a PR comment, use a complete, itemized response.
 
+### Feedback Retrieval Checklist
+Before claiming that all PR feedback was reviewed or addressed, inspect every
+available feedback surface:
+- Top-level PR review bodies.
+- PR conversation comments.
+- Inline PR review comments and review threads.
+
+For GitHub PRs, use retrieval that covers all pages of each surface. Equivalent
+tools are acceptable, but the retrieval must cover these REST API surfaces:
+- Top-level reviews: `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews`
+  (for example, `gh api --paginate repos/OWNER/REPO/pulls/NUMBER/reviews`).
+- Inline review comments: `GET /repos/{owner}/{repo}/pulls/{pull_number}/comments`
+  (for example, `gh api --paginate repos/OWNER/REPO/pulls/NUMBER/comments`).
+- PR conversation comments: `GET /repos/{owner}/{repo}/issues/{issue_number}/comments`
+  (for example, `gh api --paginate repos/OWNER/REPO/issues/NUMBER/comments`).
+
+When using raw REST calls instead of `gh api --paginate`, follow pagination
+headers such as `Link: rel="next"` until no next page remains. Fetching only
+the first page is not sufficient on active PRs.
+
+### Response Coverage
+- Address every actionable finding from every retrieved feedback surface; do
+  not collapse multiple findings into one vague bullet.
+- If the same issue appears in multiple places, it may be fixed once, but the
+  response must explicitly acknowledge the duplicate surfaces or state that
+  duplicate findings are grouped.
+- Top-level feedback-response comments may reference inline findings by
+  `path:line`, GitHub links, or equivalent anchors. This is allowed for
+  feedback responses and does not override the prohibition on imitating inline
+  review comments inside top-level review bodies.
+
 ### Required Coverage
-- Address every finding from the review being responded to; do not collapse multiple findings into one vague bullet.
-- For each finding, mark one status: `Resolved`, `Partially Resolved`, or `Not Changed`.
+- For each actionable finding identified by the retrieval checklist, mark one
+  status: `Resolved`, `Partially Resolved`, or `Not Changed`.
 - If a finding is `Partially Resolved` or `Not Changed`, explain exactly what remains and why.
 
 ### Evidence Requirements


### PR DESCRIPTION
> 🤖 Prepared by Codex GPT-5 · via Codex CLI

## Summary
- Problem: The review-feedback response workflow did not explicitly require checking every GitHub feedback surface before claiming all PR feedback was handled.
- Approach: Add a concrete retrieval checklist for top-level reviews, PR conversation comments, and inline review comments/threads, including paginated GitHub REST and `gh api` examples.
- Outcome: Generated project policy now makes all-feedback response work harder to do partially or accidentally.

Closes #86.

## Changes
- `scaffold/agent-vault/review-policy.md`: adds a `Feedback Retrieval Checklist`, required GitHub retrieval surfaces, pagination guidance, duplicate-feedback grouping guidance, and explicit allowance for feedback responses to cite inline findings by `path:line`.
- `scaffold/agent-vault/shared-rules.md`: adds a pointer to the review-policy retrieval checklist when agents are asked to review, summarize, respond to, or address all PR feedback.
- `AGENTS.md`, `scaffold/root/AGENTS.md`, and `scaffold/agent-vault/AGENTS.md`: update mirrored policy/workflow text to stay in sync.

## Verification Loop
- Build / package: Not applicable; Markdown policy scaffold change only.
- Typecheck / static analysis: Not applicable; no code paths changed.
- Lint / format validation: `git diff --check` - passed.
- Tests / coverage: `bash scripts/check-policy-mirrors.sh` - passed.
- Security / secrets review: No secrets or executable workflow changes. The policy now explicitly names GitHub REST endpoints and pagination behavior.
- Diff review: Reviewed the policy diff and mirrored files for drift, formatting, and issue-plan alignment.

## Risks and Rollback
- Risk: The retrieval checklist adds more process text to an already detailed review policy.
- Mitigation: The three-surface list lives in `review-policy.md`; `shared-rules.md` only points to it to reduce duplicated policy surface.
- Rollback: Revert this PR to return to the previous feedback-response policy wording.

## Docs Consistency
- `docs/design.md`: No impact; this changes generated-project review workflow policy, not architecture/design behavior.
- `README.md`: No impact; this is internal policy text already covered by existing generated-structure docs.
