### PR TITLE
Flag missing lint format tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,14 @@ When performing a code review on this repository, behave like a senior backend e
 - Changes in files outside the PR diff
 - Intentional policy duplication between root `AGENTS.md` and `scaffold/agent-vault/review-policy.md` (Codex compatibility); flag only if files drift.
 - Pre-existing issues not introduced by the PR. Use git blame or commit history to distinguish inherited code from new changes. Only flag pre-existing issues if they create an immediate risk in combination with PR changes.
-- Issues that linters, formatters, or type checkers already catch. Assume CI enforces these; do not duplicate their coverage.
+- Issues that configured linters, formatters, or type checkers already catch
+  when those tools are present and enforced. Do not assume lint/format tooling
+  exists when it is not configured.
+- A missing lint/format tooling gap after it has been durably acknowledged in
+  `agent-vault/coding-standards.md` or an accepted decision record referenced from
+  `agent-vault/decision-log.md`. Until that acknowledgement exists, reviewers
+  may flag the gap as `Recommended` when they have high confidence that no
+  lint/format tooling is configured.
 - Nitpicks with no functional, security, or maintainability impact.
 
 ## AI and Agent-Specific Safety Requirements

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ When performing a code review on this repository, behave like a senior backend e
 - A missing lint/format tooling gap after it has been durably acknowledged in
   `agent-vault/coding-standards.md` or an accepted decision record referenced from
   `agent-vault/decision-log.md`. Until that acknowledgement exists, reviewers
-  may flag the gap as `Recommended` when they have high confidence that no
+  should flag the gap as `Recommended` when they have high confidence that no
   lint/format tooling is configured.
 - Nitpicks with no functional, security, or maintainability impact.
 

--- a/scaffold/agent-vault/AGENTS.md
+++ b/scaffold/agent-vault/AGENTS.md
@@ -104,11 +104,14 @@
   - Build / package: confirm the changed artifact can be produced when the repo has a build, bundle, or packaging step.
   - Typecheck / static analysis: run compiler, type-system, or equivalent static checks when the repo uses them.
   - Lint / format validation: run lint or formatting validation when the repo uses them.
+    If no lint or format tooling is configured, check whether that gap is documented in `agent-vault/coding-standards.md` or in an accepted decision record referenced from `agent-vault/decision-log.md`.
+    If it is not documented, the final summary or PR body MUST state that lint/format validation was unavailable or unconfigured and recommend adding tooling or documenting the intentional gap.
   - Tests / coverage: run the most relevant automated tests for the changed behavior, and include coverage checks when the repo tracks them.
   - Security / secrets review: run applicable dependency, secret, or security-sensitive checks when the change touches auth, permissions, external inputs, shell execution, CI/workflows, infrastructure, or secret handling.
   - Diff review: inspect the final diff against the base branch for unintended edits, leftover debug code, documentation drift, and missing `agent-vault` metadata updates.
 - If a step fails, fix the issue and rerun the relevant parts of the loop before proceeding.
 - If a step is unavailable or not meaningful for the repo, explicitly say so in the final summary or PR body instead of implying it ran.
+- If lint/format tooling is unavailable or unconfigured, this disclosure is required unless the gap is already documented in `agent-vault/coding-standards.md` or in an accepted decision record referenced from `agent-vault/decision-log.md`.
 
 ## Code Style
 - Follow the primary language, framework, and toolchain guidance recorded in `agent-vault/coding-standards.md`.

--- a/scaffold/agent-vault/AGENTS.md
+++ b/scaffold/agent-vault/AGENTS.md
@@ -111,7 +111,6 @@
   - Diff review: inspect the final diff against the base branch for unintended edits, leftover debug code, documentation drift, and missing `agent-vault` metadata updates.
 - If a step fails, fix the issue and rerun the relevant parts of the loop before proceeding.
 - If a step is unavailable or not meaningful for the repo, explicitly say so in the final summary or PR body instead of implying it ran.
-- If lint/format tooling is unavailable or unconfigured, this disclosure is required unless the gap is already documented in `agent-vault/coding-standards.md` or in an accepted decision record referenced from `agent-vault/decision-log.md`.
 
 ## Code Style
 - Follow the primary language, framework, and toolchain guidance recorded in `agent-vault/coding-standards.md`.

--- a/scaffold/agent-vault/review-policy.md
+++ b/scaffold/agent-vault/review-policy.md
@@ -85,7 +85,14 @@ When performing a code review on this repository, behave like a senior backend e
 - Changes in files outside the PR diff
 - Intentional policy duplication between root `AGENTS.md` and `agent-vault/review-policy.md` (Codex compatibility); flag only if files drift.
 - Pre-existing issues not introduced by the PR. Use git blame or commit history to distinguish inherited code from new changes. Only flag pre-existing issues if they create an immediate risk in combination with PR changes.
-- Issues that linters, formatters, or type checkers already catch. Assume CI enforces these; do not duplicate their coverage.
+- Issues that configured linters, formatters, or type checkers already catch
+  when those tools are present and enforced. Do not assume lint/format tooling
+  exists when it is not configured.
+- A missing lint/format tooling gap after it has been durably acknowledged in
+  `agent-vault/coding-standards.md` or an accepted decision record referenced from
+  `agent-vault/decision-log.md`. Until that acknowledgement exists, reviewers
+  may flag the gap as `Recommended` when they have high confidence that no
+  lint/format tooling is configured.
 - Nitpicks with no functional, security, or maintainability impact.
 
 ## AI and Agent-Specific Safety Requirements

--- a/scaffold/agent-vault/review-policy.md
+++ b/scaffold/agent-vault/review-policy.md
@@ -91,7 +91,7 @@ When performing a code review on this repository, behave like a senior backend e
 - A missing lint/format tooling gap after it has been durably acknowledged in
   `agent-vault/coding-standards.md` or an accepted decision record referenced from
   `agent-vault/decision-log.md`. Until that acknowledgement exists, reviewers
-  may flag the gap as `Recommended` when they have high confidence that no
+  should flag the gap as `Recommended` when they have high confidence that no
   lint/format tooling is configured.
 - Nitpicks with no functional, security, or maintainability impact.
 

--- a/scaffold/agent-vault/shared-rules.md
+++ b/scaffold/agent-vault/shared-rules.md
@@ -106,7 +106,6 @@
   - Diff review: inspect the final diff against the base branch for unintended edits, leftover debug code, documentation drift, and missing `agent-vault` metadata updates.
 - If a step fails, fix the issue and rerun the relevant parts of the loop before proceeding.
 - If a step is unavailable or not meaningful for the repo, explicitly say so in the final summary or PR body instead of implying it ran.
-- If lint/format tooling is unavailable or unconfigured, this disclosure is required unless the gap is already documented in `agent-vault/coding-standards.md` or in an accepted decision record referenced from `agent-vault/decision-log.md`.
 
 ## Code Style
 - Follow the primary language, framework, and toolchain guidance recorded in `agent-vault/coding-standards.md`.

--- a/scaffold/agent-vault/shared-rules.md
+++ b/scaffold/agent-vault/shared-rules.md
@@ -99,11 +99,14 @@
   - Build / package: confirm the changed artifact can be produced when the repo has a build, bundle, or packaging step.
   - Typecheck / static analysis: run compiler, type-system, or equivalent static checks when the repo uses them.
   - Lint / format validation: run lint or formatting validation when the repo uses them.
+    If no lint or format tooling is configured, check whether that gap is documented in `agent-vault/coding-standards.md` or in an accepted decision record referenced from `agent-vault/decision-log.md`.
+    If it is not documented, the final summary or PR body MUST state that lint/format validation was unavailable or unconfigured and recommend adding tooling or documenting the intentional gap.
   - Tests / coverage: run the most relevant automated tests for the changed behavior, and include coverage checks when the repo tracks them.
   - Security / secrets review: run applicable dependency, secret, or security-sensitive checks when the change touches auth, permissions, external inputs, shell execution, CI/workflows, infrastructure, or secret handling.
   - Diff review: inspect the final diff against the base branch for unintended edits, leftover debug code, documentation drift, and missing `agent-vault` metadata updates.
 - If a step fails, fix the issue and rerun the relevant parts of the loop before proceeding.
 - If a step is unavailable or not meaningful for the repo, explicitly say so in the final summary or PR body instead of implying it ran.
+- If lint/format tooling is unavailable or unconfigured, this disclosure is required unless the gap is already documented in `agent-vault/coding-standards.md` or in an accepted decision record referenced from `agent-vault/decision-log.md`.
 
 ## Code Style
 - Follow the primary language, framework, and toolchain guidance recorded in `agent-vault/coding-standards.md`.

--- a/scaffold/root/AGENTS.md
+++ b/scaffold/root/AGENTS.md
@@ -119,7 +119,14 @@ When performing a code review on this repository, behave like a senior backend e
 - Changes in files outside the PR diff
 - Intentional policy duplication between root `AGENTS.md` and `agent-vault/review-policy.md` (Codex compatibility); flag only if files drift.
 - Pre-existing issues not introduced by the PR. Use git blame or commit history to distinguish inherited code from new changes. Only flag pre-existing issues if they create an immediate risk in combination with PR changes.
-- Issues that linters, formatters, or type checkers already catch. Assume CI enforces these; do not duplicate their coverage.
+- Issues that configured linters, formatters, or type checkers already catch
+  when those tools are present and enforced. Do not assume lint/format tooling
+  exists when it is not configured.
+- A missing lint/format tooling gap after it has been durably acknowledged in
+  `agent-vault/coding-standards.md` or an accepted decision record referenced from
+  `agent-vault/decision-log.md`. Until that acknowledgement exists, reviewers
+  may flag the gap as `Recommended` when they have high confidence that no
+  lint/format tooling is configured.
 - Nitpicks with no functional, security, or maintainability impact.
 
 ## AI and Agent-Specific Safety Requirements

--- a/scaffold/root/AGENTS.md
+++ b/scaffold/root/AGENTS.md
@@ -125,7 +125,7 @@ When performing a code review on this repository, behave like a senior backend e
 - A missing lint/format tooling gap after it has been durably acknowledged in
   `agent-vault/coding-standards.md` or an accepted decision record referenced from
   `agent-vault/decision-log.md`. Until that acknowledgement exists, reviewers
-  may flag the gap as `Recommended` when they have high confidence that no
+  should flag the gap as `Recommended` when they have high confidence that no
   lint/format tooling is configured.
 - Nitpicks with no functional, security, or maintainability impact.
 


### PR DESCRIPTION
> 🤖 Prepared by Codex GPT-5 · via Codex CLI

## Summary
- Problem: The Verification Loop allowed lint/format validation to be silently skipped when a repo had no lint or format tooling, while the review policy assumed such tooling existed.
- Approach: Make missing lint/format tooling an explicit Verification Loop disclosure unless it is durably documented, and update review guidance so reviewers do not assume lint/format coverage exists.
- Outcome: Generated project policy now flags undocumented lint/format tooling gaps instead of letting them disappear across PR cycles.

Closes #87.

## Changes
- `scaffold/agent-vault/shared-rules.md`: requires agents to check whether missing lint/format tooling is documented in `agent-vault/coding-standards.md` or an accepted decision record referenced from `agent-vault/decision-log.md`; if not, PR/final summaries must disclose the unavailable or unconfigured lint/format step and recommend adding tooling or documenting the intentional gap.
- `scaffold/agent-vault/review-policy.md`: narrows the lint/typecheck do-not-flag rule to configured and enforced tooling, and allows reviewers to flag undocumented missing lint/format tooling as `Recommended` when high confidence.
- `AGENTS.md`, `scaffold/root/AGENTS.md`, and `scaffold/agent-vault/AGENTS.md`: update mirrored policy/workflow text to stay in sync.

## Verification Loop
- Build / package: Not applicable; Markdown policy scaffold change only.
- Typecheck / static analysis: Not applicable; no code paths changed.
- Lint / format validation: `git diff --check` - passed.
- Tests / coverage: `bash scripts/check-policy-mirrors.sh` - passed.
- Security / secrets review: No secrets or executable workflow changes.
- Diff review: Reviewed the policy diff and mirrored files for drift, readability, and issue-plan alignment.

## Risks and Rollback
- Risk: The policy may surface more review findings in repos that intentionally do not use lint/format tooling but have not documented that choice.
- Mitigation: The policy provides a durable acknowledgement path through `agent-vault/coding-standards.md` or an accepted decision record referenced from `agent-vault/decision-log.md`.
- Rollback: Revert this PR to return to the previous Verification Loop and Do Not Flag wording.

## Docs Consistency
- `docs/design.md`: No impact; this changes generated-project workflow and review policy, not architecture/design behavior.
- `README.md`: No impact; update behavior already syncs managed policy files via `update-project.sh`.
