### PR TITLE
Document portable memory artifact paths

### DIFF
--- a/scaffold/agent-vault/AGENTS.md
+++ b/scaffold/agent-vault/AGENTS.md
@@ -166,6 +166,7 @@ Use the canonical ordering for each artifact type below instead of guessing base
 
 ## Template Usage Rules
 - Use the bootstrap files in place. Do not create duplicate `README.md`, `plan.md`, `coding-standards.md`, `context-log.md`, `open-questions.md`, or `decision-log.md` notes elsewhere.
+- In committed memory artifacts, prefer repo-relative paths and portable command examples such as `agent-vault/...`, `docs/...`, `./scripts/...`, or `<repo-root>/...`. Machine-specific absolute paths such as `/Users/...`, `/home/...`, or `C:\...` are acceptable only when the local path itself is relevant debugging or environment context.
 - Create or update `agent-vault/daily/YYYY-MM-DD.md` on the first substantive work session of each local day. Reuse the same file for later sessions that day. Skip daily notes for trivial one-off requests.
 - Add a design-log note for every substantive work session.
 - When a durable decision is made about architecture, workflow, API shape, data model, deployment, or tool policy, create a decision record in `agent-vault/decisions/` and add it to `agent-vault/decision-log.md`.

--- a/scaffold/agent-vault/AGENTS.md
+++ b/scaffold/agent-vault/AGENTS.md
@@ -125,6 +125,7 @@
 ## PR Authoring Standards
 - When creating a pull request, include a complete PR body; do not open with a one-line summary only.
 - Use an imperative, outcome-focused title that reflects the actual change scope.
+- Do not prefix PR titles with agent or client identifiers such as `[codex]`, `[claude]`, or `[agent]` unless the repository explicitly requires that format.
 - Keep PR scope coherent; split unrelated work into separate PRs.
 - Prefer opening as draft until validation is complete, unless the user asks otherwise.
 - PR body must include:

--- a/scaffold/agent-vault/Templates/Context Log.md
+++ b/scaffold/agent-vault/Templates/Context Log.md
@@ -11,6 +11,7 @@ last_updated:
 - Entry headings must start with `YYYY-MM-DD HH:MM local - <agent> - <topic>`.
 - Keep entries short and concrete.
 - Reference files and PRs instead of pasting long diffs.
+- Prefer repo-relative paths where possible.
 - Pair each major update with a design-log entry.
 - Add a handoff note when transferring work between agents/sessions.
 - Reference the active handoff note or decision record when one changes current work.

--- a/scaffold/agent-vault/Templates/Daily Note.md
+++ b/scaffold/agent-vault/Templates/Daily Note.md
@@ -14,7 +14,7 @@ last_updated:
 - [ ]
 
 ## Work Log
-<!-- Keep same-day work chronological. Append new entries or added session sections at the bottom. -->
+<!-- Keep same-day work chronological. Append new entries or added session sections at the bottom. Prefer repo-relative paths where possible. -->
 - HH:MM - 
 
 ## Decisions / Key Updates

--- a/scaffold/agent-vault/Templates/Design Log Entry.md
+++ b/scaffold/agent-vault/Templates/Design Log Entry.md
@@ -16,6 +16,7 @@ scope:
 ## Open Issues
 
 ## Related Artifacts
+<!-- Prefer repo-relative paths where possible. -->
 - `agent-vault/daily/...`
 - `agent-vault/decisions/...`
 - `agent-vault/context/handoffs/...`

--- a/scaffold/agent-vault/Templates/Handoff Note.md
+++ b/scaffold/agent-vault/Templates/Handoff Note.md
@@ -24,6 +24,7 @@ topic:
 <!-- Explain external tools, APIs, and services on first mention. See shared-rules.md "Write for a Context-Free Reader". -->
 
 ## Relevant Files
+<!-- Prefer repo-relative paths where possible. -->
 - 
 
 ## Decisions Made This Session

--- a/scaffold/agent-vault/context-log.md
+++ b/scaffold/agent-vault/context-log.md
@@ -11,6 +11,7 @@ last_updated: __DATE__
 - Entry headings must start with `YYYY-MM-DD HH:MM local - <agent> - <topic>`.
 - Keep entries short and concrete.
 - Reference files and PRs instead of pasting long diffs.
+- Prefer repo-relative paths where possible.
 - Pair each major update with a design-log entry.
 - Add a handoff note when switching agents or ending a session.
 - Reference the active handoff note or decision record when one changes current work.

--- a/scaffold/agent-vault/shared-rules.md
+++ b/scaffold/agent-vault/shared-rules.md
@@ -161,6 +161,7 @@ Use the canonical ordering for each artifact type below instead of guessing base
 
 ## Template Usage Rules
 - Use the bootstrap files in place. Do not create duplicate `README.md`, `plan.md`, `coding-standards.md`, `context-log.md`, `open-questions.md`, or `decision-log.md` notes elsewhere.
+- In committed memory artifacts, prefer repo-relative paths and portable command examples such as `agent-vault/...`, `docs/...`, `./scripts/...`, or `<repo-root>/...`. Machine-specific absolute paths such as `/Users/...`, `/home/...`, or `C:\...` are acceptable only when the local path itself is relevant debugging or environment context.
 - Create or update `agent-vault/daily/YYYY-MM-DD.md` on the first substantive work session of each local day. Reuse the same file for later sessions that day. Skip daily notes for trivial one-off requests.
 - Add a design-log note for every substantive work session.
 - When a durable decision is made about architecture, workflow, API shape, data model, deployment, or tool policy, create a decision record in `agent-vault/decisions/` and add it to `agent-vault/decision-log.md`.

--- a/scaffold/agent-vault/shared-rules.md
+++ b/scaffold/agent-vault/shared-rules.md
@@ -120,6 +120,7 @@
 ## PR Authoring Standards
 - When creating a pull request, include a complete PR body; do not open with a one-line summary only.
 - Use an imperative, outcome-focused title that reflects the actual change scope.
+- Do not prefix PR titles with agent or client identifiers such as `[codex]`, `[claude]`, or `[agent]` unless the repository explicitly requires that format.
 - Keep PR scope coherent; split unrelated work into separate PRs.
 - Prefer opening as draft until validation is complete, unless the user asks otherwise.
 - PR body must include:


### PR DESCRIPTION
## Summary

Closes #39.

This PR adds explicit scaffold guidance that committed `agent-vault` memory artifacts should prefer repo-relative paths and portable command examples over machine-specific absolute filesystem paths. It keeps the exception for cases where an absolute local path is the actual debugging or environment context.

It also clarifies PR title conventions so generated projects do not inherit agent/client title prefixes such as `[codex]` unless a repository explicitly requires that format.

Scope note: the PR-title convention was added during PR review after owner feedback identified the `[codex]` prefix as a recurring cross-project agent behavior. It is intentionally included here as adjacent scaffold authoring guidance rather than split into a separate issue.

## Files / Areas Changed

- `scaffold/agent-vault/shared-rules.md`: adds the durable memory-artifact path rule under `Template Usage Rules` and clarifies PR title conventions under `PR Authoring Standards`.
- `scaffold/agent-vault/AGENTS.md`: mirrors the shared workflow guidance so generated Codex-compatible instructions stay in sync.
- `scaffold/agent-vault/Templates/Design Log Entry.md`, `Daily Note.md`, and `Handoff Note.md`: add lightweight positive nudges to prefer repo-relative paths.
- `scaffold/agent-vault/Templates/Context Log.md` and `scaffold/agent-vault/context-log.md`: add the same concise guidance next to the existing file/PR reference prompt.

## Verification Loop Evidence

- `bash scripts/check-policy-mirrors.sh` - passed.
- `bash scripts/test-decision-template-sync.sh` - passed.
- `bash scripts/test-session-metadata-hook.sh` - passed.
- `bash scripts/test-gitignore-management.sh` - passed.
- `git diff --check` - passed.

No additional runtime test suite is applicable because this is a scaffold documentation/template change.

## Risks / Rollback

Risk is low. The change only updates generated guidance and templates; it does not change sync mechanics, hooks, or runtime behavior. Rollback is a straight revert of the doc/template commits if the wording proves too noisy.

## Docs Consistency

No README or `design.md` update needed. The issue plan explicitly kept this as scaffold-internal memory-artifact guidance rather than top-level user-facing workflow documentation.
