### PR TITLE
Add review emphasis triggers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,18 @@ When performing a code review on this repository, behave like a senior backend e
 - Agents must still recommend a preferred option with rationale. Do not use the trade-off label as an excuse to stay noncommittal.
 - Do not present one trade-off choice as mandatory unless the PR conflicts with an `accepted` decision record, a user-approved plan, or an explicit documented requirement.
 
+### Emphasis Triggers
+Use these triggers to decide which existing priorities deserve extra scrutiny based on PR scope. They guide review attention only; do not list triggers, lenses, or focused passes in the posted review body unless they explain an actual finding.
+
+| Scope trigger | Emphasize priority |
+| --- | --- |
+| Auth, permissions, secrets, CI/workflows, shell or tool execution, unsafe HTML/deserialization, model/tool invocation changes, or untrusted input handling | Security and Data Safety; AI and Agent-Specific Safety Requirements |
+| External services, retries, timeouts, queues, background jobs, cleanup scripts, or partial-failure behavior | Reliability and Observability |
+| CLI flags, setup steps, generated templates, public APIs/contracts, `docs/design.md`, `README.md`, or documented architecture boundaries | Requirements Alignment |
+| Refactors, new helpers, new abstractions, duplicated logic, or broad policy/template changes | Maintainability and System Design |
+| Behavior changes, bug fixes, validation rules, state transitions, or edge-case handling | Correctness and Edge Cases; Testing Expectations |
+| Cost-sensitive loops, batching, caching, model calls, or concurrency limits | Performance and Cost |
+
 ## Severity Mapping
 - Critical = P0 (blocks merge)
 - Recommended = P1 (should fix before merge)

--- a/scaffold/agent-vault/review-policy.md
+++ b/scaffold/agent-vault/review-policy.md
@@ -72,6 +72,18 @@ When performing a code review on this repository, behave like a senior backend e
 - Agents must still recommend a preferred option with rationale. Do not use the trade-off label as an excuse to stay noncommittal.
 - Do not present one trade-off choice as mandatory unless the PR conflicts with an `accepted` decision record, a user-approved plan, or an explicit documented requirement.
 
+### Emphasis Triggers
+Use these triggers to decide which existing priorities deserve extra scrutiny based on PR scope. They guide review attention only; do not list triggers, lenses, or focused passes in the posted review body unless they explain an actual finding.
+
+| Scope trigger | Emphasize priority |
+| --- | --- |
+| Auth, permissions, secrets, CI/workflows, shell or tool execution, unsafe HTML/deserialization, model/tool invocation changes, or untrusted input handling | Security and Data Safety; AI and Agent-Specific Safety Requirements |
+| External services, retries, timeouts, queues, background jobs, cleanup scripts, or partial-failure behavior | Reliability and Observability |
+| CLI flags, setup steps, generated templates, public APIs/contracts, `docs/design.md`, `README.md`, or documented architecture boundaries | Requirements Alignment |
+| Refactors, new helpers, new abstractions, duplicated logic, or broad policy/template changes | Maintainability and System Design |
+| Behavior changes, bug fixes, validation rules, state transitions, or edge-case handling | Correctness and Edge Cases; Testing Expectations |
+| Cost-sensitive loops, batching, caching, model calls, or concurrency limits | Performance and Cost |
+
 ## Severity Mapping
 - Critical = P0 (blocks merge)
 - Recommended = P1 (should fix before merge)

--- a/scaffold/root/AGENTS.md
+++ b/scaffold/root/AGENTS.md
@@ -106,6 +106,18 @@ When performing a code review on this repository, behave like a senior backend e
 - Agents must still recommend a preferred option with rationale. Do not use the trade-off label as an excuse to stay noncommittal.
 - Do not present one trade-off choice as mandatory unless the PR conflicts with an `accepted` decision record, a user-approved plan, or an explicit documented requirement.
 
+### Emphasis Triggers
+Use these triggers to decide which existing priorities deserve extra scrutiny based on PR scope. They guide review attention only; do not list triggers, lenses, or focused passes in the posted review body unless they explain an actual finding.
+
+| Scope trigger | Emphasize priority |
+| --- | --- |
+| Auth, permissions, secrets, CI/workflows, shell or tool execution, unsafe HTML/deserialization, model/tool invocation changes, or untrusted input handling | Security and Data Safety; AI and Agent-Specific Safety Requirements |
+| External services, retries, timeouts, queues, background jobs, cleanup scripts, or partial-failure behavior | Reliability and Observability |
+| CLI flags, setup steps, generated templates, public APIs/contracts, `docs/design.md`, `README.md`, or documented architecture boundaries | Requirements Alignment |
+| Refactors, new helpers, new abstractions, duplicated logic, or broad policy/template changes | Maintainability and System Design |
+| Behavior changes, bug fixes, validation rules, state transitions, or edge-case handling | Correctness and Edge Cases; Testing Expectations |
+| Cost-sensitive loops, batching, caching, model calls, or concurrency limits | Performance and Cost |
+
 ## Severity Mapping
 - Critical = P0 (blocks merge)
 - Recommended = P1 (should fix before merge)


### PR DESCRIPTION
## Summary

Closes #33.

This PR adds a compact `### Emphasis Triggers` subsection to the PR review policy. Instead of creating a parallel review-lenses taxonomy, it maps common PR scopes to the existing review priorities that deserve extra scrutiny.

## Files / Areas Changed

- `scaffold/agent-vault/review-policy.md`: adds the trigger-to-priority table and no-boilerplate rule.
- `AGENTS.md`: mirrors the review-policy block for Codex-compatible root review flows.
- `scaffold/root/AGENTS.md`: mirrors the generated root wrapper review-policy block.

## Approach

The section follows the final issue plan:

- Uses a two-column `Scope trigger` / `Emphasize priority` table.
- Anchors priority names to existing policy headings such as `Security and Data Safety`, `Reliability and Observability`, and `Requirements Alignment`.
- Tells reviewers not to list triggers, lenses, or focused passes in posted reviews unless they explain an actual finding.

## Verification Loop Evidence

- `bash scripts/check-policy-mirrors.sh` - passed.
- `git diff --check` - passed.

No runtime test suite is applicable because this is a mirrored policy documentation change.

## Risks / Rollback

Risk is low. The main risk is policy bloat, which this avoids by reusing existing priorities instead of adding a separate lens taxonomy. Rollback is a straight revert of the policy commit.

## Docs Consistency

No README or `docs/design.md` update needed. This is internal PR review policy guidance and is already mirrored to the required review-policy surfaces.