### PR TITLE
Add opt-in metadata-only main push gate

### DIFF
--- a/.github/workflows/scaffold-regression-checks.yml
+++ b/.github/workflows/scaffold-regression-checks.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/test-coding-standards-sync.sh"
       - "scripts/test-decision-template-sync.sh"
       - "scripts/test-session-metadata-hook.sh"
+      - "scripts/test-main-push-gate.sh"
       - "scripts/test-new-worktree.sh"
       - "scripts/test-remove-worktree.sh"
       - "scripts/test-worktree-helper-sync.sh"
@@ -31,6 +32,7 @@ on:
       - "scripts/test-coding-standards-sync.sh"
       - "scripts/test-decision-template-sync.sh"
       - "scripts/test-session-metadata-hook.sh"
+      - "scripts/test-main-push-gate.sh"
       - "scripts/test-new-worktree.sh"
       - "scripts/test-remove-worktree.sh"
       - "scripts/test-worktree-helper-sync.sh"
@@ -51,6 +53,8 @@ jobs:
         run: bash scripts/test-decision-template-sync.sh
       - name: Verify session metadata hook behavior
         run: bash scripts/test-session-metadata-hook.sh
+      - name: Verify main push metadata gate
+        run: bash scripts/test-main-push-gate.sh
       - name: Verify worktree creation helper
         run: bash scripts/test-new-worktree.sh
       - name: Verify worktree removal helper

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Run the scaffold regression scripts locally when changing bootstrap, sync, or tr
 - `bash scripts/test-coding-standards-sync.sh`
 - `bash scripts/test-decision-template-sync.sh`
 - `bash scripts/test-session-metadata-hook.sh`
+- `bash scripts/test-main-push-gate.sh`
 - `bash scripts/test-new-worktree.sh`
 - `bash scripts/test-remove-worktree.sh`
 - `bash scripts/test-worktree-helper-sync.sh`
@@ -111,7 +112,9 @@ CI also runs these checks via `.github/workflows/scaffold-regression-checks.yml`
   - `<repo>/agent-vault/GEMINI.md`
   - `<repo>/agent-vault/handoff.md`
   - `<repo>/agent-vault/_assets/hooks/README.md`
+  - `<repo>/agent-vault/_assets/hooks/lib/runtime-note.sh`
   - `<repo>/agent-vault/_assets/hooks/pre-commit`
+  - `<repo>/agent-vault/_assets/hooks/pre-push`
   - `<repo>/agent-vault/design-log/README.md`
   - `<repo>/agent-vault/context/handoffs/README.md`
   - `<repo>/agent-vault/decisions/README.md`
@@ -177,7 +180,10 @@ When a managed file changes, the script backs up the previous version under:
 Generated projects auto-enable the tracked metadata gate in the clone where `new-project.sh` or `update-project.sh` runs, unless `core.hooksPath` is already set to something else. Additional clones can enable it with:
 - `git -C <repo-path> config core.hooksPath agent-vault/_assets/hooks`
 
-That tracked hook enforces the baseline session artifacts and validates staged `agent-vault/context-log.md` ordering/freshness so newer entries do not get appended below stale headers.
+The tracked `pre-commit` hook enforces the baseline session artifacts and validates staged `agent-vault/context-log.md` ordering/freshness so newer entries do not get appended below stale headers. The tracked `pre-push` hook is inert by default; repos may opt into a narrow direct-push-to-`main` shortcut for runtime `agent-vault` metadata only:
+- `git -C <repo-path> config --local agent-vault.allowMetadataOnlyMainPush true`
+
+That shortcut allows recording history after PR merges while keeping source code, config, scripts, root docs, policy files, templates, hook assets, and durable project docs such as `agent-vault/README.md`, `plan.md`, `coding-standards.md`, `project-context.md`, `project-commands.md`, and `handoff.md` on the PR path.
 When syncing older generated repos, `update-project.sh` now auto-migrates recognized legacy `agent-vault/context-log.md` layouts into the validator-compatible top-level `## Current Snapshot` / `## Entries` shape before syncing the stricter hook. If the layout is not recognized, the script leaves the file unchanged and prints a manual-remediation warning instead of guessing.
 
 Both scripts also ensure root `.gitignore` includes managed local-only ignore entries (added only when missing):
@@ -225,7 +231,7 @@ Generated projects get a starter `docs/design.md` that uses Mermaid fenced code 
 - `open-questions.md`
 - `lessons.md`
 - `handoff.md`
-- `daily/`, `context/`, `design-log/`, `decisions/`, `_assets/` (including the optional tracked `pre-commit` hook under `agent-vault/_assets/hooks/`)
+- `daily/`, `context/`, `design-log/`, `decisions/`, `_assets/` (including the optional tracked hooks under `agent-vault/_assets/hooks/`)
 - `Templates/` (copied from template source; instantiated notes belong outside this folder)
 
 It also creates project-root files when missing:

--- a/scaffold/agent-vault/AGENTS.md
+++ b/scaffold/agent-vault/AGENTS.md
@@ -233,6 +233,12 @@ When performing research or writing research-oriented documentation (design-log 
 - Before creating a commit for substantive work, make sure today's daily note, context log, and any new design-log entry do not leave same-session publication mechanics (`git commit`, `git push`, PR creation) in `Carry Forward`, `Next`, or equivalent future-tense text unless those actions will truly remain unfinished after the session.
 - Treat these updates as a commit gate for substantive work, not as optional cleanup after the code is already done.
 
+## Direct Push to Main
+- Direct push to `main` is acceptable only when the repo has explicitly opted into the tracked `pre-push` shortcut and the push records runtime `agent-vault` metadata only.
+- Use direct metadata pushes to record history after a PR merge: what landed, current state, follow-ups, changed decisions, known risks, or cleanup notes.
+- Do not use the shortcut for behavior-changing files. Source code, config, scripts, root docs, `agent-vault/README.md`, `plan.md`, `coding-standards.md`, `project-context.md`, `project-commands.md`, `handoff.md`, policy files, templates, and hook assets still require PR review.
+- If a post-merge metadata refresh would be empty or ceremonial, skip it and say no metadata update was needed.
+
 ## Completion Verification - MUST follow before marking any task done
 Before reporting a task as finished:
 1. Run the Verification Loop appropriate to the repo and change scope.
@@ -280,7 +286,7 @@ Before considering any change complete and before running git commit:
   - `agent-vault/decision-log.md` plus the decision record when a durable decision was made
   - `agent-vault/context/handoffs/` when handing off unfinished work
   - `agent-vault/lessons.md` when a corrected mistake should become a durable prevention rule
-- If the repo enables the tracked hook at `agent-vault/_assets/hooks/pre-commit`, keep it enabled via `git config core.hooksPath agent-vault/_assets/hooks`.
+- If the repo enables the tracked hooks under `agent-vault/_assets/hooks/`, keep them enabled via `git config core.hooksPath agent-vault/_assets/hooks`.
 - If a change is truly trivial and should not update project memory, make that an explicit decision and say so in your final summary instead of silently skipping the metadata step.
 
 ## Additional Guardrails

--- a/scaffold/agent-vault/_assets/hooks/README.md
+++ b/scaffold/agent-vault/_assets/hooks/README.md
@@ -10,7 +10,7 @@ Enable the tracked hooks for the current clone:
 git config core.hooksPath agent-vault/_assets/hooks
 ```
 
-## Current Hook
+## Current Hooks
 
 - `pre-commit`
   - Blocks commits with substantive staged changes unless the staged diff also includes:
@@ -22,6 +22,38 @@ git config core.hooksPath agent-vault/_assets/hooks
     - entries must remain newest-first
     - frontmatter and Current Snapshot `Last updated` must match the top entry date
   - This is a baseline gate only. Conditional artifacts such as `open-questions.md`, decision records, handoff notes, and `lessons.md` still depend on the actual session outcome.
+- `pre-push`
+  - Inert by default.
+  - When explicitly enabled with local repo config, blocks direct pushes to `main` unless every pushed path is runtime `agent-vault` metadata.
+  - Rejects direct deletion of `main`, first-time creation of `main`, and non-fast-forward pushes.
+  - Uses the same runtime metadata classifier as `pre-commit`.
+
+## Optional Direct Push to Main for Runtime Metadata
+
+Direct push to `main` is allowed for recording history, not changing behavior. Enable the narrow post-merge metadata shortcut only in repos that intentionally want it:
+
+```bash
+git config --local agent-vault.allowMetadataOnlyMainPush true
+```
+
+The shortcut allows only runtime metadata files:
+
+- `agent-vault/context-log.md`
+- `agent-vault/open-questions.md`
+- `agent-vault/decision-log.md`
+- `agent-vault/lessons.md`
+- notes under `agent-vault/daily/`, excluding `README.md`
+- notes under `agent-vault/design-log/`, excluding `README.md` and `bootstrap.md`
+- notes under `agent-vault/context/handoffs/`, excluding `README.md`
+- decision records under `agent-vault/decisions/`, excluding `README.md`
+
+Everything else still requires the normal PR flow, including source code, config, scripts, root docs, `agent-vault/README.md`, `plan.md`, `coding-standards.md`, `project-context.md`, `project-commands.md`, `handoff.md`, policy files, templates, and hook assets.
+
+Rollback:
+
+```bash
+git config --local --unset agent-vault.allowMetadataOnlyMainPush
+```
 
 ## Intentional Bypass
 

--- a/scaffold/agent-vault/_assets/hooks/lib/runtime-note.sh
+++ b/scaffold/agent-vault/_assets/hooks/lib/runtime-note.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+is_runtime_note_file() {
+  local file_path="$1"
+
+  case "$file_path" in
+    agent-vault/context-log.md|agent-vault/open-questions.md|agent-vault/decision-log.md|agent-vault/lessons.md)
+      return 0
+      ;;
+    agent-vault/daily/*.md)
+      [[ "$file_path" != "agent-vault/daily/README.md" ]]
+      return
+      ;;
+    agent-vault/design-log/*.md)
+      [[ "$file_path" != "agent-vault/design-log/README.md" && "$file_path" != "agent-vault/design-log/bootstrap.md" ]]
+      return
+      ;;
+    agent-vault/context/handoffs/*.md)
+      [[ "$file_path" != "agent-vault/context/handoffs/README.md" ]]
+      return
+      ;;
+    agent-vault/decisions/*.md)
+      [[ "$file_path" != "agent-vault/decisions/README.md" ]]
+      return
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}

--- a/scaffold/agent-vault/_assets/hooks/pre-commit
+++ b/scaffold/agent-vault/_assets/hooks/pre-commit
@@ -17,34 +17,8 @@ if [[ ! -d "agent-vault" ]]; then
   exit 0
 fi
 
-is_runtime_note_file() {
-  local file_path="$1"
-
-  case "$file_path" in
-    agent-vault/context-log.md|agent-vault/open-questions.md|agent-vault/decision-log.md|agent-vault/lessons.md)
-      return 0
-      ;;
-    agent-vault/daily/*.md)
-      [[ "$file_path" != "agent-vault/daily/README.md" ]]
-      return
-      ;;
-    agent-vault/design-log/*.md)
-      [[ "$file_path" != "agent-vault/design-log/README.md" && "$file_path" != "agent-vault/design-log/bootstrap.md" ]]
-      return
-      ;;
-    agent-vault/context/handoffs/*.md)
-      [[ "$file_path" != "agent-vault/context/handoffs/README.md" ]]
-      return
-      ;;
-    agent-vault/decisions/*.md)
-      [[ "$file_path" != "agent-vault/decisions/README.md" ]]
-      return
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
+# shellcheck source=./lib/runtime-note.sh
+source "agent-vault/_assets/hooks/lib/runtime-note.sh"
 
 extract_context_log_frontmatter_value() {
   local file_path="$1"

--- a/scaffold/agent-vault/_assets/hooks/pre-push
+++ b/scaffold/agent-vault/_assets/hooks/pre-push
@@ -41,6 +41,18 @@ reject_main_push() {
   exit 1
 }
 
+collect_commit_changed_files() {
+  local commit_sha="$1"
+  local first_parent=""
+
+  first_parent="$(git rev-parse "$commit_sha^1" 2>/dev/null || true)"
+  if [[ -n "$first_parent" ]]; then
+    git diff --no-renames --name-only "$first_parent" "$commit_sha"
+  else
+    git diff-tree --no-commit-id --name-only -r --no-renames --root "$commit_sha"
+  fi
+}
+
 while read -r local_ref local_sha remote_ref remote_sha; do
   [[ "$remote_ref" == "refs/heads/main" ]] || continue
 
@@ -56,14 +68,20 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     reject_main_push "Direct non-fast-forward push to main is not allowed."
   fi
 
+  # Check each commit, not just endpoint trees, so blocked files cannot be
+  # changed and reverted inside the pushed range.
   blocked_files=()
-  while IFS= read -r file_path; do
-    [[ -n "$file_path" ]] || continue
+  while IFS= read -r commit_sha; do
+    [[ -n "$commit_sha" ]] || continue
 
-    if ! is_runtime_note_file "$file_path"; then
-      blocked_files+=("$file_path")
-    fi
-  done < <(git diff --no-renames --name-only "$remote_sha" "$local_sha")
+    while IFS= read -r file_path; do
+      [[ -n "$file_path" ]] || continue
+
+      if ! is_runtime_note_file "$file_path"; then
+        blocked_files+=("$file_path")
+      fi
+    done < <(collect_commit_changed_files "$commit_sha")
+  done < <(git rev-list --reverse "$remote_sha..$local_sha")
 
   if [[ "${#blocked_files[@]}" -gt 0 ]]; then
     echo "agent-vault main push gate failed." >&2

--- a/scaffold/agent-vault/_assets/hooks/pre-push
+++ b/scaffold/agent-vault/_assets/hooks/pre-push
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+zero_sha="0000000000000000000000000000000000000000"
+config_key="agent-vault.allowMetadataOnlyMainPush"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" ]]; then
+  exit 0
+fi
+
+cd "$repo_root"
+
+if [[ ! -d "agent-vault" ]]; then
+  exit 0
+fi
+
+config_value=""
+config_rc=0
+config_value="$(git config --local --get --type=bool "$config_key" 2>/dev/null)" || config_rc=$?
+if [[ "$config_rc" -ne 0 && "$config_rc" -ne 1 ]]; then
+  echo "agent-vault main push gate failed." >&2
+  echo "Invalid local git config value for $config_key; expected true or false." >&2
+  exit 1
+fi
+
+if [[ "$config_value" != "true" ]]; then
+  exit 0
+fi
+
+# shellcheck source=./lib/runtime-note.sh
+source "agent-vault/_assets/hooks/lib/runtime-note.sh"
+
+reject_main_push() {
+  local reason="$1"
+
+  echo "agent-vault main push gate failed." >&2
+  echo "$reason" >&2
+  echo "Use the PR flow for source, config, policy, hook, template, or mixed changes." >&2
+  exit 1
+}
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [[ "$remote_ref" == "refs/heads/main" ]] || continue
+
+  if [[ "$local_sha" == "$zero_sha" ]]; then
+    reject_main_push "Direct deletion of main is not allowed."
+  fi
+
+  if [[ "$remote_sha" == "$zero_sha" ]]; then
+    reject_main_push "Direct creation of main is not allowed."
+  fi
+
+  if ! git merge-base --is-ancestor "$remote_sha" "$local_sha"; then
+    reject_main_push "Direct non-fast-forward push to main is not allowed."
+  fi
+
+  blocked_files=()
+  while IFS= read -r file_path; do
+    [[ -n "$file_path" ]] || continue
+
+    if ! is_runtime_note_file "$file_path"; then
+      blocked_files+=("$file_path")
+    fi
+  done < <(git diff --no-renames --name-only "$remote_sha" "$local_sha")
+
+  if [[ "${#blocked_files[@]}" -gt 0 ]]; then
+    echo "agent-vault main push gate failed." >&2
+    echo "Direct push to main is allowed only for runtime agent-vault metadata." >&2
+    echo "Blocked path(s):" >&2
+    for file_path in "${blocked_files[@]}"; do
+      echo "- $file_path" >&2
+    done
+    echo "Use the PR flow for source, config, policy, hook, template, or mixed changes." >&2
+    exit 1
+  fi
+done

--- a/scaffold/agent-vault/shared-rules.md
+++ b/scaffold/agent-vault/shared-rules.md
@@ -228,6 +228,12 @@ When performing research or writing research-oriented documentation (design-log 
 - Before creating a commit for substantive work, make sure today's daily note, context log, and any new design-log entry do not leave same-session publication mechanics (`git commit`, `git push`, PR creation) in `Carry Forward`, `Next`, or equivalent future-tense text unless those actions will truly remain unfinished after the session.
 - Treat these updates as a commit gate for substantive work, not as optional cleanup after the code is already done.
 
+## Direct Push to Main
+- Direct push to `main` is acceptable only when the repo has explicitly opted into the tracked `pre-push` shortcut and the push records runtime `agent-vault` metadata only.
+- Use direct metadata pushes to record history after a PR merge: what landed, current state, follow-ups, changed decisions, known risks, or cleanup notes.
+- Do not use the shortcut for behavior-changing files. Source code, config, scripts, root docs, `agent-vault/README.md`, `plan.md`, `coding-standards.md`, `project-context.md`, `project-commands.md`, `handoff.md`, policy files, templates, and hook assets still require PR review.
+- If a post-merge metadata refresh would be empty or ceremonial, skip it and say no metadata update was needed.
+
 ## Completion Verification - MUST follow before marking any task done
 Before reporting a task as finished:
 1. Run the Verification Loop appropriate to the repo and change scope.
@@ -275,7 +281,7 @@ Before considering any change complete and before running git commit:
   - `agent-vault/decision-log.md` plus the decision record when a durable decision was made
   - `agent-vault/context/handoffs/` when handing off unfinished work
   - `agent-vault/lessons.md` when a corrected mistake should become a durable prevention rule
-- If the repo enables the tracked hook at `agent-vault/_assets/hooks/pre-commit`, keep it enabled via `git config core.hooksPath agent-vault/_assets/hooks`.
+- If the repo enables the tracked hooks under `agent-vault/_assets/hooks/`, keep them enabled via `git config core.hooksPath agent-vault/_assets/hooks`.
 - If a change is truly trivial and should not update project memory, make that an explicit decision and say so in your final summary instead of silently skipping the metadata step.
 
 ## Additional Guardrails

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -335,7 +335,9 @@ for required in \
   "$scaffold_dir/project-context.md" \
   "$scaffold_dir/project-commands.md" \
   "$scaffold_dir/_assets/hooks/README.md" \
+  "$scaffold_dir/_assets/hooks/lib/runtime-note.sh" \
   "$scaffold_dir/_assets/hooks/pre-commit" \
+  "$scaffold_dir/_assets/hooks/pre-push" \
   "$scaffold_dir/design-log/README.md" \
   "$scaffold_dir/context/handoffs/README.md" \
   "$scaffold_dir/decisions/README.md" \

--- a/scripts/test-main-push-gate.sh
+++ b/scripts/test-main-push-gate.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/agent-vault-main-push-gate-test.XXXXXX")"
+today="$(date '+%Y-%m-%d')"
+zero_sha="0000000000000000000000000000000000000000"
+
+cleanup() {
+  rm -rf "$tmp_root"
+}
+
+trap cleanup EXIT
+
+assert_output_contains() {
+  local output="$1"
+  local expected_text="$2"
+
+  if [[ "$output" != *"$expected_text"* ]]; then
+    echo "Expected text not found in command output: $expected_text" >&2
+    echo "Actual output:" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+}
+
+assert_file_exists() {
+  local file_path="$1"
+
+  if [[ ! -f "$file_path" ]]; then
+    echo "Expected file not found: $file_path" >&2
+    exit 1
+  fi
+}
+
+assert_executable() {
+  local file_path="$1"
+
+  if [[ ! -x "$file_path" ]]; then
+    echo "Expected executable file: $file_path" >&2
+    exit 1
+  fi
+}
+
+init_repo() {
+  local repo_path="$1"
+
+  mkdir -p "$repo_path"
+  git -C "$repo_path" init >/dev/null
+  git -C "$repo_path" checkout -b main >/dev/null 2>&1
+  git -C "$repo_path" config user.name "Agent Vault Test"
+  git -C "$repo_path" config user.email "agent-vault-tests@example.com"
+}
+
+seed_project() {
+  local repo_path="$1"
+
+  init_repo "$repo_path"
+  "$repo_root/scripts/new-project.sh" "push-gate-test" "$repo_path" >/dev/null
+  assert_file_exists "$repo_path/agent-vault/_assets/hooks/lib/runtime-note.sh"
+  assert_file_exists "$repo_path/agent-vault/_assets/hooks/pre-push"
+  assert_executable "$repo_path/agent-vault/_assets/hooks/pre-push"
+  git -C "$repo_path" add .
+  (cd "$repo_path" && AGENT_VAULT_SKIP_METADATA_GATE=1 git commit -m "Bootstrap push gate test fixture" >/dev/null)
+}
+
+enable_gate() {
+  local repo_path="$1"
+
+  git -C "$repo_path" config --local agent-vault.allowMetadataOnlyMainPush true
+}
+
+commit_metadata_change() {
+  local repo_path="$1"
+
+  printf '\nPost-merge metadata refresh.\n' >>"$repo_path/agent-vault/context-log.md"
+  git -C "$repo_path" add agent-vault/context-log.md
+  (cd "$repo_path" && AGENT_VAULT_SKIP_METADATA_GATE=1 git commit -m "Update agent-vault metadata" >/dev/null)
+}
+
+commit_source_change() {
+  local repo_path="$1"
+
+  mkdir -p "$repo_path/src"
+  printf 'print("source change")\n' >"$repo_path/src/app.py"
+  git -C "$repo_path" add src/app.py
+  (cd "$repo_path" && AGENT_VAULT_SKIP_METADATA_GATE=1 git commit -m "Change source" >/dev/null)
+}
+
+commit_mixed_change() {
+  local repo_path="$1"
+
+  mkdir -p "$repo_path/src"
+  printf 'print("mixed change")\n' >"$repo_path/src/app.py"
+  printf '\nMixed metadata refresh.\n' >>"$repo_path/agent-vault/context-log.md"
+  git -C "$repo_path" add src/app.py agent-vault/context-log.md
+  (cd "$repo_path" && AGENT_VAULT_SKIP_METADATA_GATE=1 git commit -m "Change source and metadata" >/dev/null)
+}
+
+run_pre_push() {
+  local repo_path="$1"
+  local local_ref="$2"
+  local local_sha="$3"
+  local remote_ref="$4"
+  local remote_sha="$5"
+
+  (cd "$repo_path" && printf '%s %s %s %s\n' "$local_ref" "$local_sha" "$remote_ref" "$remote_sha" | agent-vault/_assets/hooks/pre-push)
+}
+
+run_pre_push_expect_failure() {
+  local repo_path="$1"
+  local local_ref="$2"
+  local local_sha="$3"
+  local remote_ref="$4"
+  local remote_sha="$5"
+  local output=""
+
+  if output="$(run_pre_push "$repo_path" "$local_ref" "$local_sha" "$remote_ref" "$remote_sha" 2>&1)"; then
+    echo "Expected pre-push hook to fail in $repo_path" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$output"
+}
+
+opt_out_repo="$tmp_root/opt-out-source-allowed"
+seed_project "$opt_out_repo"
+opt_out_remote_sha="$(git -C "$opt_out_repo" rev-parse HEAD)"
+commit_source_change "$opt_out_repo"
+opt_out_local_sha="$(git -C "$opt_out_repo" rev-parse HEAD)"
+run_pre_push "$opt_out_repo" "refs/heads/main" "$opt_out_local_sha" "refs/heads/main" "$opt_out_remote_sha"
+
+global_config_repo="$tmp_root/global-config-ignored"
+global_config_file="$tmp_root/global-config.gitconfig"
+seed_project "$global_config_repo"
+git config --file "$global_config_file" agent-vault.allowMetadataOnlyMainPush true
+global_config_remote_sha="$(git -C "$global_config_repo" rev-parse HEAD)"
+commit_source_change "$global_config_repo"
+global_config_local_sha="$(git -C "$global_config_repo" rev-parse HEAD)"
+(cd "$global_config_repo" && printf '%s %s %s %s\n' \
+  "refs/heads/main" "$global_config_local_sha" "refs/heads/main" "$global_config_remote_sha" \
+  | GIT_CONFIG_GLOBAL="$global_config_file" agent-vault/_assets/hooks/pre-push)
+
+metadata_repo="$tmp_root/metadata-only-allowed"
+seed_project "$metadata_repo"
+enable_gate "$metadata_repo"
+metadata_remote_sha="$(git -C "$metadata_repo" rev-parse HEAD)"
+commit_metadata_change "$metadata_repo"
+metadata_local_sha="$(git -C "$metadata_repo" rev-parse HEAD)"
+run_pre_push "$metadata_repo" "refs/heads/main" "$metadata_local_sha" "refs/heads/main" "$metadata_remote_sha"
+
+source_repo="$tmp_root/source-blocked"
+seed_project "$source_repo"
+enable_gate "$source_repo"
+source_remote_sha="$(git -C "$source_repo" rev-parse HEAD)"
+commit_source_change "$source_repo"
+source_local_sha="$(git -C "$source_repo" rev-parse HEAD)"
+source_output="$(run_pre_push_expect_failure "$source_repo" "refs/heads/main" "$source_local_sha" "refs/heads/main" "$source_remote_sha")"
+assert_output_contains "$source_output" "Direct push to main is allowed only for runtime agent-vault metadata."
+assert_output_contains "$source_output" "- src/app.py"
+
+mixed_repo="$tmp_root/mixed-blocked"
+seed_project "$mixed_repo"
+enable_gate "$mixed_repo"
+mixed_remote_sha="$(git -C "$mixed_repo" rev-parse HEAD)"
+commit_mixed_change "$mixed_repo"
+mixed_local_sha="$(git -C "$mixed_repo" rev-parse HEAD)"
+mixed_output="$(run_pre_push_expect_failure "$mixed_repo" "refs/heads/main" "$mixed_local_sha" "refs/heads/main" "$mixed_remote_sha")"
+assert_output_contains "$mixed_output" "- src/app.py"
+
+feature_repo="$tmp_root/non-main-unaffected"
+seed_project "$feature_repo"
+enable_gate "$feature_repo"
+feature_remote_sha="$(git -C "$feature_repo" rev-parse HEAD)"
+commit_source_change "$feature_repo"
+feature_local_sha="$(git -C "$feature_repo" rev-parse HEAD)"
+run_pre_push "$feature_repo" "refs/heads/feature" "$feature_local_sha" "refs/heads/feature" "$feature_remote_sha"
+
+for blocked_path in \
+  agent-vault/AGENTS.md \
+  agent-vault/shared-rules.md \
+  agent-vault/review-policy.md \
+  "agent-vault/Templates/Plan.md" \
+  agent-vault/_assets/hooks/pre-commit
+do
+  blocked_repo="$tmp_root/blocked-${blocked_path//\//-}"
+  seed_project "$blocked_repo"
+  enable_gate "$blocked_repo"
+  blocked_remote_sha="$(git -C "$blocked_repo" rev-parse HEAD)"
+  printf '\nBlocked direct-main change.\n' >>"$blocked_repo/$blocked_path"
+  git -C "$blocked_repo" add "$blocked_path"
+  (cd "$blocked_repo" && AGENT_VAULT_SKIP_METADATA_GATE=1 git commit -m "Change blocked agent-vault file" >/dev/null)
+  blocked_local_sha="$(git -C "$blocked_repo" rev-parse HEAD)"
+  blocked_output="$(run_pre_push_expect_failure "$blocked_repo" "refs/heads/main" "$blocked_local_sha" "refs/heads/main" "$blocked_remote_sha")"
+  assert_output_contains "$blocked_output" "- $blocked_path"
+done
+
+delete_repo="$tmp_root/delete-main-blocked"
+seed_project "$delete_repo"
+enable_gate "$delete_repo"
+delete_remote_sha="$(git -C "$delete_repo" rev-parse HEAD)"
+delete_output="$(run_pre_push_expect_failure "$delete_repo" "refs/heads/main" "$zero_sha" "refs/heads/main" "$delete_remote_sha")"
+assert_output_contains "$delete_output" "Direct deletion of main is not allowed."
+
+create_repo="$tmp_root/create-main-blocked"
+seed_project "$create_repo"
+enable_gate "$create_repo"
+create_local_sha="$(git -C "$create_repo" rev-parse HEAD)"
+create_output="$(run_pre_push_expect_failure "$create_repo" "refs/heads/main" "$create_local_sha" "refs/heads/main" "$zero_sha")"
+assert_output_contains "$create_output" "Direct creation of main is not allowed."
+
+non_ff_repo="$tmp_root/non-fast-forward-blocked"
+seed_project "$non_ff_repo"
+enable_gate "$non_ff_repo"
+non_ff_base_sha="$(git -C "$non_ff_repo" rev-parse HEAD)"
+commit_metadata_change "$non_ff_repo"
+non_ff_local_sha="$(git -C "$non_ff_repo" rev-parse HEAD)"
+git -C "$non_ff_repo" checkout -b remote-side "$non_ff_base_sha" >/dev/null 2>&1
+mkdir -p "$non_ff_repo/remote"
+printf 'remote side\n' >"$non_ff_repo/remote/file.txt"
+git -C "$non_ff_repo" add remote/file.txt
+(cd "$non_ff_repo" && AGENT_VAULT_SKIP_METADATA_GATE=1 git commit -m "Remote side divergence" >/dev/null)
+non_ff_remote_sha="$(git -C "$non_ff_repo" rev-parse HEAD)"
+non_ff_output="$(run_pre_push_expect_failure "$non_ff_repo" "refs/heads/main" "$non_ff_local_sha" "refs/heads/main" "$non_ff_remote_sha")"
+assert_output_contains "$non_ff_output" "Direct non-fast-forward push to main is not allowed."
+
+rename_repo="$tmp_root/rename-source-blocked"
+seed_project "$rename_repo"
+enable_gate "$rename_repo"
+rename_remote_sha="$(git -C "$rename_repo" rev-parse HEAD)"
+git -C "$rename_repo" mv agent-vault/AGENTS.md "agent-vault/daily/$today-renamed.md"
+(cd "$rename_repo" && AGENT_VAULT_SKIP_METADATA_GATE=1 git commit -m "Rename policy into runtime note path" >/dev/null)
+rename_local_sha="$(git -C "$rename_repo" rev-parse HEAD)"
+rename_output="$(run_pre_push_expect_failure "$rename_repo" "refs/heads/main" "$rename_local_sha" "refs/heads/main" "$rename_remote_sha")"
+assert_output_contains "$rename_output" "- agent-vault/AGENTS.md"
+
+invalid_config_repo="$tmp_root/invalid-config"
+seed_project "$invalid_config_repo"
+git -C "$invalid_config_repo" config --local agent-vault.allowMetadataOnlyMainPush maybe
+invalid_config_remote_sha="$(git -C "$invalid_config_repo" rev-parse HEAD)"
+commit_metadata_change "$invalid_config_repo"
+invalid_config_local_sha="$(git -C "$invalid_config_repo" rev-parse HEAD)"
+invalid_config_output="$(run_pre_push_expect_failure "$invalid_config_repo" "refs/heads/main" "$invalid_config_local_sha" "refs/heads/main" "$invalid_config_remote_sha")"
+assert_output_contains "$invalid_config_output" "Invalid local git config value for agent-vault.allowMetadataOnlyMainPush"
+
+echo "main push metadata gate regression checks passed."

--- a/scripts/test-main-push-gate.sh
+++ b/scripts/test-main-push-gate.sh
@@ -132,6 +132,20 @@ commit_source_change "$opt_out_repo"
 opt_out_local_sha="$(git -C "$opt_out_repo" rev-parse HEAD)"
 run_pre_push "$opt_out_repo" "refs/heads/main" "$opt_out_local_sha" "refs/heads/main" "$opt_out_remote_sha"
 
+no_vault_repo="$tmp_root/no-agent-vault-noop"
+init_repo "$no_vault_repo"
+printf 'plain repo\n' >"$no_vault_repo/README.md"
+git -C "$no_vault_repo" add README.md
+git -C "$no_vault_repo" commit -m "Bootstrap plain repo" >/dev/null
+git -C "$no_vault_repo" config --local agent-vault.allowMetadataOnlyMainPush true
+no_vault_remote_sha="$(git -C "$no_vault_repo" rev-parse HEAD)"
+printf 'plain repo update\n' >"$no_vault_repo/README.md"
+git -C "$no_vault_repo" commit -am "Change plain repo" >/dev/null
+no_vault_local_sha="$(git -C "$no_vault_repo" rev-parse HEAD)"
+(cd "$no_vault_repo" && printf '%s %s %s %s\n' \
+  "refs/heads/main" "$no_vault_local_sha" "refs/heads/main" "$no_vault_remote_sha" \
+  | "$repo_root/scaffold/agent-vault/_assets/hooks/pre-push")
+
 global_config_repo="$tmp_root/global-config-ignored"
 global_config_file="$tmp_root/global-config.gitconfig"
 seed_project "$global_config_repo"
@@ -151,6 +165,14 @@ commit_metadata_change "$metadata_repo"
 metadata_local_sha="$(git -C "$metadata_repo" rev-parse HEAD)"
 run_pre_push "$metadata_repo" "refs/heads/main" "$metadata_local_sha" "refs/heads/main" "$metadata_remote_sha"
 
+empty_commit_repo="$tmp_root/empty-commit-allowed"
+seed_project "$empty_commit_repo"
+enable_gate "$empty_commit_repo"
+empty_commit_remote_sha="$(git -C "$empty_commit_repo" rev-parse HEAD)"
+git -C "$empty_commit_repo" commit --allow-empty -m "Empty metadata checkpoint" >/dev/null
+empty_commit_local_sha="$(git -C "$empty_commit_repo" rev-parse HEAD)"
+run_pre_push "$empty_commit_repo" "refs/heads/main" "$empty_commit_local_sha" "refs/heads/main" "$empty_commit_remote_sha"
+
 source_repo="$tmp_root/source-blocked"
 seed_project "$source_repo"
 enable_gate "$source_repo"
@@ -169,6 +191,20 @@ commit_mixed_change "$mixed_repo"
 mixed_local_sha="$(git -C "$mixed_repo" rev-parse HEAD)"
 mixed_output="$(run_pre_push_expect_failure "$mixed_repo" "refs/heads/main" "$mixed_local_sha" "refs/heads/main" "$mixed_remote_sha")"
 assert_output_contains "$mixed_output" "- src/app.py"
+
+range_repo="$tmp_root/intermediate-blocked-file-blocked"
+seed_project "$range_repo"
+enable_gate "$range_repo"
+range_remote_sha="$(git -C "$range_repo" rev-parse HEAD)"
+printf '\nTemporary policy change.\n' >>"$range_repo/agent-vault/AGENTS.md"
+git -C "$range_repo" add agent-vault/AGENTS.md
+(cd "$range_repo" && AGENT_VAULT_SKIP_METADATA_GATE=1 git commit -m "Temporarily change policy" >/dev/null)
+git -C "$range_repo" checkout "$range_remote_sha" -- agent-vault/AGENTS.md
+git -C "$range_repo" add agent-vault/AGENTS.md
+(cd "$range_repo" && AGENT_VAULT_SKIP_METADATA_GATE=1 git commit -m "Revert temporary policy change" >/dev/null)
+range_local_sha="$(git -C "$range_repo" rev-parse HEAD)"
+range_output="$(run_pre_push_expect_failure "$range_repo" "refs/heads/main" "$range_local_sha" "refs/heads/main" "$range_remote_sha")"
+assert_output_contains "$range_output" "- agent-vault/AGENTS.md"
 
 feature_repo="$tmp_root/non-main-unaffected"
 seed_project "$feature_repo"

--- a/scripts/test-session-metadata-hook.sh
+++ b/scripts/test-session-metadata-hook.sh
@@ -116,8 +116,11 @@ hook_repo="$tmp_root/hook-enforcement"
 init_repo "$hook_repo"
 "$repo_root/scripts/new-project.sh" "hook-test" "$hook_repo" >/dev/null
 assert_file_exists "$hook_repo/agent-vault/_assets/hooks/pre-commit"
+assert_file_exists "$hook_repo/agent-vault/_assets/hooks/pre-push"
+assert_file_exists "$hook_repo/agent-vault/_assets/hooks/lib/runtime-note.sh"
 assert_file_exists "$hook_repo/agent-vault/_assets/hooks/README.md"
 assert_executable "$hook_repo/agent-vault/_assets/hooks/pre-commit"
+assert_executable "$hook_repo/agent-vault/_assets/hooks/pre-push"
 if [[ "$(git -C "$hook_repo" config --local --get core.hooksPath)" != "agent-vault/_assets/hooks" ]]; then
   echo "Expected new-project.sh to enable the tracked hooks path." >&2
   exit 1
@@ -177,8 +180,11 @@ git -C "$update_repo" config --local --unset core.hooksPath
 rm -rf "$update_repo/agent-vault/_assets/hooks"
 "$repo_root/scripts/update-project.sh" "$update_repo" >/dev/null
 assert_file_exists "$update_repo/agent-vault/_assets/hooks/pre-commit"
+assert_file_exists "$update_repo/agent-vault/_assets/hooks/pre-push"
+assert_file_exists "$update_repo/agent-vault/_assets/hooks/lib/runtime-note.sh"
 assert_file_exists "$update_repo/agent-vault/_assets/hooks/README.md"
 assert_executable "$update_repo/agent-vault/_assets/hooks/pre-commit"
+assert_executable "$update_repo/agent-vault/_assets/hooks/pre-push"
 if [[ "$(git -C "$update_repo" config --local --get core.hooksPath)" != "agent-vault/_assets/hooks" ]]; then
   echo "Expected update-project.sh to enable the tracked hooks path." >&2
   exit 1

--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -142,7 +142,9 @@ for required in \
   "$vault_scaffold_dir/project-commands.md" \
   "$vault_scaffold_dir/lessons.md" \
   "$vault_scaffold_dir/_assets/hooks/README.md" \
+  "$vault_scaffold_dir/_assets/hooks/lib/runtime-note.sh" \
   "$vault_scaffold_dir/_assets/hooks/pre-commit" \
+  "$vault_scaffold_dir/_assets/hooks/pre-push" \
   "$vault_scaffold_dir/design-log/README.md" \
   "$vault_scaffold_dir/context/handoffs/README.md" \
   "$vault_scaffold_dir/decisions/README.md" \
@@ -219,7 +221,9 @@ preflight_symlink_checks() {
   assert_not_symlink "$project_dir/review-policy.md" "agent-vault/review-policy.md"
   assert_not_symlink "$project_dir/handoff.md" "agent-vault/handoff.md"
   assert_not_symlink "$project_dir/_assets/hooks/README.md" "agent-vault/_assets/hooks/README.md"
+  assert_not_symlink "$project_dir/_assets/hooks/lib/runtime-note.sh" "agent-vault/_assets/hooks/lib/runtime-note.sh"
   assert_not_symlink "$project_dir/_assets/hooks/pre-commit" "agent-vault/_assets/hooks/pre-commit"
+  assert_not_symlink "$project_dir/_assets/hooks/pre-push" "agent-vault/_assets/hooks/pre-push"
   assert_not_symlink "$project_dir/design-log/README.md" "agent-vault/design-log/README.md"
   assert_not_symlink "$project_dir/context/handoffs/README.md" "agent-vault/context/handoffs/README.md"
   assert_not_symlink "$project_dir/decisions/README.md" "agent-vault/decisions/README.md"
@@ -505,6 +509,7 @@ migrate_legacy_context_log_if_needed() {
     printf -- '- `agent-vault/context-log.md`\n'
     printf -- '- `agent-vault/shared-rules.md`\n'
     printf -- '- `agent-vault/_assets/hooks/pre-commit`\n'
+    printf -- '- `agent-vault/_assets/hooks/pre-push`\n'
   } >"$tmp_file"
 
   if [[ -n "$legacy_unindexed_body" ]]; then
@@ -916,7 +921,9 @@ sync_managed_file "$vault_scaffold_dir/GEMINI.md" "$project_dir/GEMINI.md"
 sync_managed_file "$vault_scaffold_dir/handoff.md" "$project_dir/handoff.md"
 migrate_legacy_context_log_if_needed
 sync_managed_file "$vault_scaffold_dir/_assets/hooks/README.md" "$project_dir/_assets/hooks/README.md"
-sync_managed_file "$vault_scaffold_dir/_assets/hooks/pre-commit" "$project_dir/_assets/hooks/pre-commit"
+sync_managed_file "$vault_scaffold_dir/_assets/hooks/lib/runtime-note.sh" "$project_dir/_assets/hooks/lib/runtime-note.sh"
+sync_managed_executable_file "$vault_scaffold_dir/_assets/hooks/pre-commit" "$project_dir/_assets/hooks/pre-commit"
+sync_managed_executable_file "$vault_scaffold_dir/_assets/hooks/pre-push" "$project_dir/_assets/hooks/pre-push"
 sync_managed_file "$vault_scaffold_dir/design-log/README.md" "$project_dir/design-log/README.md"
 sync_managed_file "$vault_scaffold_dir/context/handoffs/README.md" "$project_dir/context/handoffs/README.md"
 sync_managed_file "$vault_scaffold_dir/decisions/README.md" "$project_dir/decisions/README.md"


### PR DESCRIPTION
## Summary

Closes #94.

This adds an opt-in tracked `pre-push` gate that lets generated repos allow direct pushes to `main` only when the pushed range contains runtime `agent-vault` metadata. The hook is inert by default and activates only from repo-local config, so existing consumers do not inherit a direct-push policy change unless they opt in.

## Files / Areas Changed

- `scaffold/agent-vault/_assets/hooks/lib/runtime-note.sh`: extracts the runtime metadata path classifier so `pre-commit` and `pre-push` share one allowlist.
- `scaffold/agent-vault/_assets/hooks/pre-commit`: sources the shared classifier instead of carrying a duplicate allowlist.
- `scaffold/agent-vault/_assets/hooks/pre-push`: adds the opt-in main push gate, including local-only config, main-only evaluation, delete/create/non-fast-forward rejection, and conservative `git diff --no-renames --name-only` path checks.
- `scripts/new-project.sh` and `scripts/update-project.sh`: propagate the new hook assets and preserve executable bits for hook files.
- `README.md`, `scaffold/agent-vault/_assets/hooks/README.md`, `scaffold/agent-vault/shared-rules.md`, and mirrored `AGENTS.md`: document the policy line that direct push is for recording runtime history, while behavior-changing files stay on the PR path.
- `.github/workflows/scaffold-regression-checks.yml` and hook tests: add CI coverage for the main push gate.

## Verification

- `bash scripts/test-main-push-gate.sh` - passed
- `bash scripts/test-session-metadata-hook.sh` - passed
- `bash scripts/check-policy-mirrors.sh` - passed
- `bash scripts/test-gitignore-management.sh` - passed
- `bash scripts/test-coding-standards-sync.sh` - passed
- `bash scripts/test-decision-template-sync.sh` - passed
- `bash scripts/test-new-worktree.sh` - passed
- `bash scripts/test-remove-worktree.sh` - passed
- `bash scripts/test-worktree-helper-sync.sh` - passed
- `bash -n` on changed shell scripts/hooks - passed
- `git diff --check` - passed

## Self-Review Notes

During self-review, I found one missing regression for the repo-local config requirement. I added coverage proving a global `agent-vault.allowMetadataOnlyMainPush=true` setting is ignored unless the current repo opts in locally.

## Risks / Rollback

- Risk: generated repos that opt in may initially be surprised when behavior-changing `agent-vault` files are blocked from direct `main` pushes. The hook prints the offending paths and points back to the PR flow.
- Risk: the allowlist could drift if future hook logic bypasses the shared classifier. This PR centralizes the classifier and tests blocked policy/template/hook paths to reduce that risk.
- Rollback: unset the opt-in in a consumer repo with `git config --local --unset agent-vault.allowMetadataOnlyMainPush`, or revert the hook asset changes in this template.

## Docs Consistency

No impact on a root `docs/design.md` architecture document was detected. README and scaffold hook/policy docs were updated to describe the new opt-in behavior and intentional exclusions.