### PR TITLE
Fix stale worktree branch cleanup

### DIFF
--- a/scaffold/root/scripts/remove-worktree.sh
+++ b/scaffold/root/scripts/remove-worktree.sh
@@ -35,6 +35,14 @@ die() {
     exit 1
 }
 
+delete_local_branch() {
+    local branch_name="$1"
+
+    git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/heads/$branch_name" \
+        || die "No local branch found: $branch_name"
+    git -C "$PROJECT_DIR" branch -D "$branch_name"
+}
+
 resolve_path() {
     local raw="$1"
     if [[ "$raw" = /* ]]; then
@@ -186,10 +194,25 @@ fi
 
 if [[ -n "$BRANCH_NAME" ]]; then
     resolved_path="$(find_branch_worktree "$BRANCH_NAME" || true)"
-    [[ -n "$resolved_path" ]] || die "No worktree found for branch: $BRANCH_NAME"
+    if [[ -z "$resolved_path" ]]; then
+        if [[ "$DELETE_BRANCH" == true && -z "$TARGET_PATH" ]]; then
+            echo "No worktree found for branch; deleting local branch only:"
+            echo "  Branch: $BRANCH_NAME"
+            delete_local_branch "$BRANCH_NAME"
+            exit 0
+        fi
+        die "No worktree found for branch: $BRANCH_NAME"
+    fi
     if [[ ! -d "$resolved_path" ]]; then
         git -C "$PROJECT_DIR" worktree prune >/dev/null 2>&1 || true
-        die "Worktree record for branch '$BRANCH_NAME' points to a missing directory. Stale metadata was pruned; rerun this command to remove the remaining branch."
+        if [[ "$DELETE_BRANCH" == true && -z "$TARGET_PATH" ]]; then
+            echo "Pruned stale worktree record for missing directory: $resolved_path"
+            echo "Deleting remaining local branch:"
+            echo "  Branch: $BRANCH_NAME"
+            delete_local_branch "$BRANCH_NAME"
+            exit 0
+        fi
+        die "Worktree record for branch '$BRANCH_NAME' points to a missing directory. Stale metadata was pruned; pass --delete-branch without --path to delete the remaining local branch."
     fi
     resolved_path="$(canonical_dir "$resolved_path")" \
         || die "Worktree path does not exist: $resolved_path"
@@ -243,5 +266,5 @@ if [[ -n "$BRANCH_NAME" ]]; then
 fi
 
 if [[ "$DELETE_BRANCH" == true ]]; then
-    git -C "$PROJECT_DIR" branch -D "$BRANCH_NAME"
+    delete_local_branch "$BRANCH_NAME"
 fi

--- a/scripts/test-remove-worktree.sh
+++ b/scripts/test-remove-worktree.sh
@@ -229,6 +229,18 @@ else
   failed=$((failed + 1))
 fi
 
+rc=0
+output="$(cd "$working" && bash scripts/remove-worktree.sh --branch codex/129-stale-record --delete-branch 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "remove-stale-record-delete-branch exits 0"
+assert_output_contains "$output" "No worktree found for branch; deleting local branch only" "remove-stale-record-delete-branch reports branch-only cleanup"
+if git -C "$working" show-ref --verify --quiet refs/heads/codex/129-stale-record; then
+  echo "FAIL: remove-stale-record-delete-branch deleted branch" >&2
+  failed=$((failed + 1))
+else
+  echo "PASS: remove-stale-record-delete-branch deleted branch"
+  passed=$((passed + 1))
+fi
+
 # --- Test 11: Bad --path values fail before any safety checks use the cwd ---
 working="$(setup_repo repo11)"
 missing_path="$tmp_root/wt/missing-worktree"


### PR DESCRIPTION
> 🤖 Prepared by Codex GPT-5 · via Codex CLI

## Summary
- Problem: `scripts/remove-worktree.sh --branch <name> --delete-branch` could not recover when the branch's worktree directory had already been manually deleted. The first run pruned stale worktree metadata and exited; the rerun then failed with `No worktree found for branch`, leaving the local branch stuck.
- Approach: Teach the managed scaffold helper to treat `--delete-branch` without `--path` as an explicit branch-only cleanup request when no live worktree remains, while preserving the existing error for non-delete invocations.
- Outcome: Generated projects can now clean up a lingering local branch after stale worktree metadata is pruned.

## Changes
- `scaffold/root/scripts/remove-worktree.sh`: added `delete_local_branch` and branch-only cleanup paths for missing/stale worktrees when `--delete-branch` is explicitly requested.
- `scripts/test-remove-worktree.sh`: extended the stale-record regression to verify the rerun deletes the lingering branch successfully.

## Verification Loop
- Build / package: Not applicable - shell helper scaffold change only.
- Typecheck / static analysis: Not applicable - no typed language surface changed.
- Lint / format validation: `bash -n scaffold/root/scripts/remove-worktree.sh`; `bash -n scripts/test-remove-worktree.sh`; `git diff --check` - passed.
- Tests / coverage: `bash scripts/test-remove-worktree.sh` - 38 passed, 0 failed. `bash scripts/test-worktree-helper-sync.sh` - 27 passed, 0 failed.
- Security / secrets / workflow checks: Reviewed the shell path handling. Branch deletion remains opt-in via `--delete-branch`; path-based cleanup still refuses missing paths and branch/path mismatches.
- Diff review: Reviewed final diff before commit `65a970a`.
- Not run: Full repository test sweep was not run because the change is isolated to the worktree cleanup helper and its sync behavior; targeted helper regressions covered the changed behavior.

## Risks and Rollback
- Risk: Users who pass `--branch <name> --delete-branch` after a stale prune now delete the branch immediately instead of receiving another error.
- Mitigation: This only happens when `--delete-branch` is explicit and no `--path` is supplied, matching the documented cleanup intent.
- Rollback: Revert `65a970a` to restore the previous stale-record behavior.

## Docs Consistency
- `docs/design.md`: No impact - helper script behavior only.
- `README.md`: No impact - existing cleanup command remains correct; behavior now matches that command in the stale-record case.

## Follow-Ups
- [ ] None