### PR TITLE
Harden agent-vault hook deletion checks

### DIFF
--- a/scaffold/agent-vault/_assets/hooks/README.md
+++ b/scaffold/agent-vault/_assets/hooks/README.md
@@ -17,6 +17,8 @@ git config core.hooksPath agent-vault/_assets/hooks
     - `agent-vault/context-log.md`
     - one note under `agent-vault/daily/`
     - one note under `agent-vault/design-log/`
+  - Rejects staged `agent-vault/` path changes when the generated `agent-vault/`
+    directory or shared runtime metadata classifier is missing.
   - Validates staged `agent-vault/context-log.md` content:
     - entry headings must use `YYYY-MM-DD HH:MM local - <agent> - <topic>`
     - entries must remain newest-first
@@ -26,6 +28,8 @@ git config core.hooksPath agent-vault/_assets/hooks
   - Inert by default.
   - When explicitly enabled with local repo config, blocks direct pushes to `main` unless every pushed path is runtime `agent-vault` metadata.
   - Rejects direct deletion of `main`, first-time creation of `main`, and non-fast-forward pushes.
+  - Rejects `main` pushes when the generated `agent-vault/` directory or shared
+    runtime metadata classifier is missing.
   - Uses the same runtime metadata classifier as `pre-commit`.
 
 ## Optional Direct Push to Main for Runtime Metadata

--- a/scaffold/agent-vault/_assets/hooks/pre-commit
+++ b/scaffold/agent-vault/_assets/hooks/pre-commit
@@ -13,8 +13,32 @@ fi
 
 cd "$repo_root"
 
-if [[ ! -d "agent-vault" ]]; then
+all_staged_files=()
+while IFS= read -r file_path; do
+  [[ -n "$file_path" ]] || continue
+  all_staged_files+=("$file_path")
+done < <(git diff --cached --name-only --diff-filter=ACDMRTUXB)
+
+if [[ "${#all_staged_files[@]}" -eq 0 ]]; then
   exit 0
+fi
+
+if [[ ! -d "agent-vault" ]]; then
+  for file_path in "${all_staged_files[@]}"; do
+    if [[ "$file_path" == "agent-vault" || "$file_path" == agent-vault/* ]]; then
+      echo "agent-vault metadata gate failed." >&2
+      echo "Tracked agent-vault directory is missing while staged changes include agent-vault paths." >&2
+      exit 1
+    fi
+  done
+
+  exit 0
+fi
+
+if [[ ! -f "agent-vault/_assets/hooks/lib/runtime-note.sh" ]]; then
+  echo "agent-vault metadata gate failed." >&2
+  echo "Runtime metadata classifier is missing." >&2
+  exit 1
 fi
 
 # shellcheck source=./lib/runtime-note.sh
@@ -157,16 +181,6 @@ validate_staged_context_log() {
   printf '%s\n' "${errors[@]}"
   return 1
 }
-
-all_staged_files=()
-while IFS= read -r file_path; do
-  [[ -n "$file_path" ]] || continue
-  all_staged_files+=("$file_path")
-done < <(git diff --cached --name-only --diff-filter=ACDMRTUXB)
-
-if [[ "${#all_staged_files[@]}" -eq 0 ]]; then
-  exit 0
-fi
 
 non_deleted_staged_files=()
 while IFS= read -r file_path; do

--- a/scaffold/agent-vault/_assets/hooks/pre-push
+++ b/scaffold/agent-vault/_assets/hooks/pre-push
@@ -12,10 +12,6 @@ fi
 
 cd "$repo_root"
 
-if [[ ! -d "agent-vault" ]]; then
-  exit 0
-fi
-
 config_value=""
 config_rc=0
 config_value="$(git config --local --get --type=bool "$config_key" 2>/dev/null)" || config_rc=$?
@@ -29,9 +25,6 @@ if [[ "$config_value" != "true" ]]; then
   exit 0
 fi
 
-# shellcheck source=./lib/runtime-note.sh
-source "agent-vault/_assets/hooks/lib/runtime-note.sh"
-
 reject_main_push() {
   local reason="$1"
 
@@ -39,6 +32,26 @@ reject_main_push() {
   echo "$reason" >&2
   echo "Use the PR flow for source, config, policy, hook, template, or mixed changes." >&2
   exit 1
+}
+
+runtime_note_classifier_loaded="false"
+
+ensure_runtime_note_classifier() {
+  if [[ "$runtime_note_classifier_loaded" == "true" ]]; then
+    return 0
+  fi
+
+  if [[ ! -d "agent-vault" ]]; then
+    reject_main_push "Tracked agent-vault directory is missing while $config_key is enabled."
+  fi
+
+  if [[ ! -f "agent-vault/_assets/hooks/lib/runtime-note.sh" ]]; then
+    reject_main_push "Runtime metadata classifier is missing while $config_key is enabled."
+  fi
+
+  # shellcheck source=./lib/runtime-note.sh
+  source "agent-vault/_assets/hooks/lib/runtime-note.sh"
+  runtime_note_classifier_loaded="true"
 }
 
 collect_commit_changed_files() {
@@ -67,6 +80,8 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   if ! git merge-base --is-ancestor "$remote_sha" "$local_sha"; then
     reject_main_push "Direct non-fast-forward push to main is not allowed."
   fi
+
+  ensure_runtime_note_classifier
 
   # Check each commit, not just endpoint trees, so blocked files cannot be
   # changed and reverted inside the pushed range.

--- a/scripts/test-main-push-gate.sh
+++ b/scripts/test-main-push-gate.sh
@@ -137,7 +137,6 @@ init_repo "$no_vault_repo"
 printf 'plain repo\n' >"$no_vault_repo/README.md"
 git -C "$no_vault_repo" add README.md
 git -C "$no_vault_repo" commit -m "Bootstrap plain repo" >/dev/null
-git -C "$no_vault_repo" config --local agent-vault.allowMetadataOnlyMainPush true
 no_vault_remote_sha="$(git -C "$no_vault_repo" rev-parse HEAD)"
 printf 'plain repo update\n' >"$no_vault_repo/README.md"
 git -C "$no_vault_repo" commit -am "Change plain repo" >/dev/null
@@ -145,6 +144,21 @@ no_vault_local_sha="$(git -C "$no_vault_repo" rev-parse HEAD)"
 (cd "$no_vault_repo" && printf '%s %s %s %s\n' \
   "refs/heads/main" "$no_vault_local_sha" "refs/heads/main" "$no_vault_remote_sha" \
   | "$repo_root/scaffold/agent-vault/_assets/hooks/pre-push")
+
+missing_vault_repo="$tmp_root/enabled-missing-agent-vault-blocked"
+seed_project "$missing_vault_repo"
+enable_gate "$missing_vault_repo"
+missing_vault_remote_sha="$(git -C "$missing_vault_repo" rev-parse HEAD)"
+git -C "$missing_vault_repo" rm -r agent-vault >/dev/null
+(cd "$missing_vault_repo" && git -c core.hooksPath=/dev/null commit -m "Remove agent-vault directory" >/dev/null)
+missing_vault_local_sha="$(git -C "$missing_vault_repo" rev-parse HEAD)"
+if missing_vault_output="$(cd "$missing_vault_repo" && printf '%s %s %s %s\n' \
+  "refs/heads/main" "$missing_vault_local_sha" "refs/heads/main" "$missing_vault_remote_sha" \
+  | "$repo_root/scaffold/agent-vault/_assets/hooks/pre-push" 2>&1)"; then
+  echo "Expected pre-push hook to fail when agent-vault is missing but the main push gate is enabled." >&2
+  exit 1
+fi
+assert_output_contains "$missing_vault_output" "Tracked agent-vault directory is missing while agent-vault.allowMetadataOnlyMainPush is enabled."
 
 global_config_repo="$tmp_root/global-config-ignored"
 global_config_file="$tmp_root/global-config.gitconfig"

--- a/scripts/test-main-push-gate.sh
+++ b/scripts/test-main-push-gate.sh
@@ -160,6 +160,16 @@ if missing_vault_output="$(cd "$missing_vault_repo" && printf '%s %s %s %s\n' \
 fi
 assert_output_contains "$missing_vault_output" "Tracked agent-vault directory is missing while agent-vault.allowMetadataOnlyMainPush is enabled."
 
+missing_classifier_repo="$tmp_root/enabled-missing-classifier-blocked"
+seed_project "$missing_classifier_repo"
+enable_gate "$missing_classifier_repo"
+missing_classifier_remote_sha="$(git -C "$missing_classifier_repo" rev-parse HEAD)"
+git -C "$missing_classifier_repo" rm agent-vault/_assets/hooks/lib/runtime-note.sh >/dev/null
+(cd "$missing_classifier_repo" && git -c core.hooksPath=/dev/null commit -m "Remove runtime metadata classifier" >/dev/null)
+missing_classifier_local_sha="$(git -C "$missing_classifier_repo" rev-parse HEAD)"
+missing_classifier_output="$(run_pre_push_expect_failure "$missing_classifier_repo" "refs/heads/main" "$missing_classifier_local_sha" "refs/heads/main" "$missing_classifier_remote_sha")"
+assert_output_contains "$missing_classifier_output" "Runtime metadata classifier is missing while agent-vault.allowMetadataOnlyMainPush is enabled."
+
 global_config_repo="$tmp_root/global-config-ignored"
 global_config_file="$tmp_root/global-config.gitconfig"
 seed_project "$global_config_repo"
@@ -227,6 +237,20 @@ feature_remote_sha="$(git -C "$feature_repo" rev-parse HEAD)"
 commit_source_change "$feature_repo"
 feature_local_sha="$(git -C "$feature_repo" rev-parse HEAD)"
 run_pre_push "$feature_repo" "refs/heads/feature" "$feature_local_sha" "refs/heads/feature" "$feature_remote_sha"
+
+multi_ref_repo="$tmp_root/multi-ref-feature-ignored"
+seed_project "$multi_ref_repo"
+enable_gate "$multi_ref_repo"
+multi_ref_base_sha="$(git -C "$multi_ref_repo" rev-parse HEAD)"
+commit_metadata_change "$multi_ref_repo"
+multi_ref_main_sha="$(git -C "$multi_ref_repo" rev-parse HEAD)"
+git -C "$multi_ref_repo" checkout -b feature-side "$multi_ref_base_sha" >/dev/null 2>&1
+commit_source_change "$multi_ref_repo"
+multi_ref_feature_sha="$(git -C "$multi_ref_repo" rev-parse HEAD)"
+(cd "$multi_ref_repo" && {
+  printf '%s %s %s %s\n' "refs/heads/feature-side" "$multi_ref_feature_sha" "refs/heads/feature-side" "$multi_ref_base_sha"
+  printf '%s %s %s %s\n' "refs/heads/main" "$multi_ref_main_sha" "refs/heads/main" "$multi_ref_base_sha"
+} | agent-vault/_assets/hooks/pre-push)
 
 for blocked_path in \
   agent-vault/AGENTS.md \

--- a/scripts/test-session-metadata-hook.sh
+++ b/scripts/test-session-metadata-hook.sh
@@ -337,6 +337,18 @@ if missing_vault_output="$(cd "$missing_vault_repo" && "$repo_root/scaffold/agen
 fi
 assert_output_contains "$missing_vault_output" "Tracked agent-vault directory is missing while staged changes include agent-vault paths."
 
+missing_classifier_repo="$tmp_root/missing-classifier-blocked"
+init_repo "$missing_classifier_repo"
+"$repo_root/scripts/new-project.sh" "hook-test" "$missing_classifier_repo" >/dev/null
+git -C "$missing_classifier_repo" add .
+(cd "$missing_classifier_repo" && AGENT_VAULT_SKIP_METADATA_GATE=1 git commit -m "Bootstrap missing classifier fixture" >/dev/null)
+git -C "$missing_classifier_repo" rm agent-vault/_assets/hooks/lib/runtime-note.sh >/dev/null
+if missing_classifier_output="$(cd "$missing_classifier_repo" && "$repo_root/scaffold/agent-vault/_assets/hooks/pre-commit" 2>&1)"; then
+  echo "Expected pre-commit hook to fail when the runtime metadata classifier is missing." >&2
+  exit 1
+fi
+assert_output_contains "$missing_classifier_output" "Runtime metadata classifier is missing."
+
 ordering_repo="$tmp_root/context-log-ordering"
 init_repo "$ordering_repo"
 "$repo_root/scripts/new-project.sh" "hook-test" "$ordering_repo" >/dev/null

--- a/scripts/test-session-metadata-hook.sh
+++ b/scripts/test-session-metadata-hook.sh
@@ -325,6 +325,18 @@ assert_output_contains "$deletion_failure_output" "stage agent-vault/context-log
 assert_output_contains "$deletion_failure_output" "stage one note under agent-vault/daily/"
 assert_output_contains "$deletion_failure_output" "stage one note under agent-vault/design-log/"
 
+missing_vault_repo="$tmp_root/missing-agent-vault-blocked"
+init_repo "$missing_vault_repo"
+"$repo_root/scripts/new-project.sh" "hook-test" "$missing_vault_repo" >/dev/null
+git -C "$missing_vault_repo" add .
+(cd "$missing_vault_repo" && AGENT_VAULT_SKIP_METADATA_GATE=1 git commit -m "Bootstrap missing vault fixture" >/dev/null)
+git -C "$missing_vault_repo" rm -r agent-vault >/dev/null
+if missing_vault_output="$(cd "$missing_vault_repo" && "$repo_root/scaffold/agent-vault/_assets/hooks/pre-commit" 2>&1)"; then
+  echo "Expected pre-commit hook to fail when staged changes remove agent-vault." >&2
+  exit 1
+fi
+assert_output_contains "$missing_vault_output" "Tracked agent-vault directory is missing while staged changes include agent-vault paths."
+
 ordering_repo="$tmp_root/context-log-ordering"
 init_repo "$ordering_repo"
 "$repo_root/scripts/new-project.sh" "hook-test" "$ordering_repo" >/dev/null


### PR DESCRIPTION
## Summary
- Problem: CritterCam PR feedback identified that generated hooks could no-op when `agent-vault/` was missing from the working tree, which weakens deletion-case enforcement for the optional metadata-only push gate.
- Approach: Fix the scaffold source hooks in `agent-vault` instead of patching CritterCam directly, and add regression coverage for missing-vault deletion scenarios.
- Outcome: The pre-push main gate now rejects enabled `main` pushes when the generated `agent-vault/` directory or runtime classifier is missing, and the pre-commit hook rejects staged `agent-vault/` path changes when the directory has been removed.

## Changes
- `scaffold/agent-vault/_assets/hooks/pre-push`: defer loading the runtime metadata classifier until a `main` update needs it, and reject `main` pushes when `agent-vault/` or the classifier is missing while `agent-vault.allowMetadataOnlyMainPush` is enabled.
- `scaffold/agent-vault/_assets/hooks/pre-commit`: collect staged files before checking for `agent-vault/`, no-op for plain repos with no staged vault paths, and reject staged `agent-vault/` changes when the directory is missing.
- `scripts/test-main-push-gate.sh`: cover the enabled missing-vault `main` push rejection while preserving plain-repo no-op behavior when the gate is not locally enabled.
- `scripts/test-session-metadata-hook.sh`: cover the staged `agent-vault/` deletion rejection path for the pre-commit hook.

## Validation
- `bash -n scaffold/agent-vault/_assets/hooks/pre-commit`: passed.
- `bash -n scaffold/agent-vault/_assets/hooks/pre-push`: passed.
- `bash -n scripts/test-main-push-gate.sh`: passed.
- `bash -n scripts/test-session-metadata-hook.sh`: passed.
- `git diff --check`: passed.
- `git diff --cached --check`: passed before commit.
- `bash scripts/test-main-push-gate.sh`: passed.
- `bash scripts/test-session-metadata-hook.sh`: passed.

## Risks and Rollback
- Risk: Repos with the optional metadata-only main-push gate enabled and a missing generated `agent-vault/` directory will now fail direct `main` pushes instead of silently no-oping.
- Mitigation: This is intentional for inconsistent generated-repo state; plain repos without the local opt-in still no-op, and non-main pushes are unaffected by the pre-push consistency check.
- Rollback: Revert commit `966a66c`.

## CritterCam Follow-Up
- Do not rerun `scripts/update-project.sh` into CritterCam until this PR merges.
- After merge, update the local `agent-vault` checkout to merged `main`, rerun the normal update script against `workspaces/crittercam`, then update CritterCam PR `#331` and respond to its feedback with the new commit evidence.
