### PR TITLE
Default managed worktrees to repo-local roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,19 @@ scripts without the marker are skipped unless you pass
 `--migrate-root-scripts`, which backs up and replaces them with the managed
 versions.
 
-The default worktree location is a sibling directory named
-`../<repo-name>-wt/`. A writing agent can run the setup helper from the original
-checkout, but the generated runbook recommends launching actual writing
-sessions from inside the generated worktree so agent sandbox permissions use
-that worktree as the active workspace.
+The default worktree location is a repo-local ignored directory named
+`.worktrees/`. A writing agent can run the setup helper from the original
+checkout, but generated instructions require the agent to switch to the printed
+worktree path before making code edits, either by launching from that directory
+or by using that path for all subsequent file operations. Users can override the
+root with `--root` or `AGENT_VAULT_WORKTREE_ROOT`.
+
+Generated guidance also treats post-merge cleanup as the standard cleanup point
+because issue branches usually map to pull requests. Before deleting a local
+branch, agents must verify the PR is merged or get explicit owner confirmation;
+otherwise they should remove only the worktree, keep the branch, and report what
+was skipped. The full cleanup recipe lives in
+`<repo>/docs/runbooks/parallel-agent-worktrees.md`.
 
 When a managed file changes, the script backs up the previous version under:
 - `<repo>/agent-vault/context/updates/<timestamp>/...`
@@ -195,6 +203,7 @@ Both scripts also ensure root `.gitignore` includes managed local-only ignore en
 - `.obsidian/backup/`
 - `.obsidian/plugins/*/data.json`
 - `/agent-vault/context/updates/`
+- `/.worktrees/`
 
 ## Migrating Existing Root Policy Files
 When running `new-project.sh` with `--migrate-existing-root-md`:

--- a/scaffold/agent-vault/AGENTS.md
+++ b/scaffold/agent-vault/AGENTS.md
@@ -56,6 +56,21 @@
 5. Self-review the result before asking for outside review. Run the Verification Loop, inspect the diff, and fix issues before moving on.
 6. Prepare the change for commit, PR, or handoff. Complete the Pre-Commit Checklist, update required `agent-vault` artifacts, and follow PR Authoring Standards when opening a PR.
 
+## Issue Worktree Workflow
+- For implementation work tied to a numbered issue, create or reuse one issue-scoped worktree before editing source files.
+- From the main checkout, derive a short slug from the issue title when possible, then run `./scripts/new-worktree.sh --agent <agent> --issue <number> --slug <slug>`.
+- Switch to the printed worktree path before code edits, either by launching from that directory or by using that path for all subsequent file operations.
+- Avoid editing the main checkout unless the user explicitly asks not to use a worktree or the work is clearly non-implementation work.
+- Keep the main checkout for integration, review, and cleanup.
+- See `docs/runbooks/parallel-agent-worktrees.md` for the full worktree workflow and cleanup recipe.
+
+## Worktree Cleanup
+- After the PR for an issue branch is merged, or when the issue work is explicitly done or abandoned, clean up the issue worktree from the main checkout or another directory outside the target worktree.
+- Before deleting a branch, verify the PR is merged with `gh pr view <branch> --json state,mergedAt`.
+- If the PR is not proven merged, ask the owner before invoking `--delete-branch`. For `OPEN`, unmerged `CLOSED`, missing PR, stale, or unclear states, default to removing only the worktree, keeping the branch, and reporting what was skipped.
+- If `remove-worktree.sh` refuses cleanup because the current process is inside the target worktree, a branch/path mismatch is unsafe, or a shared `.venv` still points into the target worktree, report the remaining cleanup step instead of forcing through.
+- Never run `--force` autonomously. It is a user-confirmed escape hatch for intentionally disposable dirty worktrees, not part of normal cleanup.
+
 ## Human Decision Gate
 - Humans are the default decision-makers for material trade-offs. When multiple technically valid options exist and the choice materially affects architecture, UX, maintainability, workflow, security posture, performance, cost, or future flexibility, do not choose silently.
 - Material trade-offs include choices such as introducing or replacing core libraries, changing API or data-model shape, relaxing validation or security controls, changing deployment or review workflow, or accepting meaningful maintainability/performance/cost trade-offs to gain speed elsewhere.

--- a/scaffold/agent-vault/project-commands.md
+++ b/scaffold/agent-vault/project-commands.md
@@ -38,10 +38,11 @@ update this file when the canonical workflow changes.
 ./scripts/remove-worktree.sh --branch codex/123-feature-slice --delete-branch
 ```
 
-The helper creates sibling worktrees under `../<repo-name>-wt/` by default.
-Launch the writing agent from inside the generated worktree so that agent
-sandbox permissions use that worktree as the active workspace. Keep the main
-checkout for integration, review, and post-merge cleanup.
+The helper creates repo-local worktrees under `.worktrees/` by default. Launch
+the writing agent from inside the generated worktree, or use that path for all
+subsequent edits. Keep the main checkout for integration, review, and cleanup.
+See `docs/runbooks/parallel-agent-worktrees.md` for the full worktree workflow,
+including branch-deletion guardrails and cleanup for done-but-unmerged work.
 
 ## Release / Operations Commands
 

--- a/scaffold/agent-vault/shared-rules.md
+++ b/scaffold/agent-vault/shared-rules.md
@@ -51,6 +51,21 @@
 5. Self-review the result before asking for outside review. Run the Verification Loop, inspect the diff, and fix issues before moving on.
 6. Prepare the change for commit, PR, or handoff. Complete the Pre-Commit Checklist, update required `agent-vault` artifacts, and follow PR Authoring Standards when opening a PR.
 
+## Issue Worktree Workflow
+- For implementation work tied to a numbered issue, create or reuse one issue-scoped worktree before editing source files.
+- From the main checkout, derive a short slug from the issue title when possible, then run `./scripts/new-worktree.sh --agent <agent> --issue <number> --slug <slug>`.
+- Switch to the printed worktree path before code edits, either by launching from that directory or by using that path for all subsequent file operations.
+- Avoid editing the main checkout unless the user explicitly asks not to use a worktree or the work is clearly non-implementation work.
+- Keep the main checkout for integration, review, and cleanup.
+- See `docs/runbooks/parallel-agent-worktrees.md` for the full worktree workflow and cleanup recipe.
+
+## Worktree Cleanup
+- After the PR for an issue branch is merged, or when the issue work is explicitly done or abandoned, clean up the issue worktree from the main checkout or another directory outside the target worktree.
+- Before deleting a branch, verify the PR is merged with `gh pr view <branch> --json state,mergedAt`.
+- If the PR is not proven merged, ask the owner before invoking `--delete-branch`. For `OPEN`, unmerged `CLOSED`, missing PR, stale, or unclear states, default to removing only the worktree, keeping the branch, and reporting what was skipped.
+- If `remove-worktree.sh` refuses cleanup because the current process is inside the target worktree, a branch/path mismatch is unsafe, or a shared `.venv` still points into the target worktree, report the remaining cleanup step instead of forcing through.
+- Never run `--force` autonomously. It is a user-confirmed escape hatch for intentionally disposable dirty worktrees, not part of normal cleanup.
+
 ## Human Decision Gate
 - Humans are the default decision-makers for material trade-offs. When multiple technically valid options exist and the choice materially affects architecture, UX, maintainability, workflow, security posture, performance, cost, or future flexibility, do not choose silently.
 - Material trade-offs include choices such as introducing or replacing core libraries, changing API or data-model shape, relaxing validation or security controls, changing deployment or review workflow, or accepting meaningful maintainability/performance/cost trade-offs to gain speed elsewhere.

--- a/scaffold/root/docs/runbooks/parallel-agent-worktrees.md
+++ b/scaffold/root/docs/runbooks/parallel-agent-worktrees.md
@@ -24,6 +24,18 @@ Use Git worktrees when you want to:
 
 Do not point multiple writing agents at the same checkout.
 
+## Agent Start Contract
+When a user asks an agent to implement or start work on a numbered issue, the
+agent should create or reuse the issue worktree before making code edits:
+
+1. Derive a short slug from the issue title when possible.
+2. Run `./scripts/new-worktree.sh --agent <agent> --issue <number> --slug <slug>`
+   from the main checkout.
+3. Switch to the printed worktree path before code edits, either by launching
+   from that directory or by using that path for all subsequent file operations.
+4. Avoid editing the main checkout unless the user explicitly asks not to use a
+   worktree or the work is clearly non-implementation work.
+
 ## Create A Worktree
 From the main checkout:
 
@@ -38,19 +50,19 @@ Other agent examples:
 ./scripts/new-worktree.sh --agent gemini --issue 125 --slug docs-followup
 ```
 
-By default the helper creates sibling worktrees under:
+By default the helper creates repo-local worktrees under:
 
 ```text
-../<repo-name>-wt/
+.worktrees/
 ```
 
 For a repository named `example-app`, the layout is:
 
 ```text
-example-app/                                  # main checkout
-example-app-wt/codex-123-feature-slice/       # issue worktree
-example-app-wt/claude-124-review-cleanup/     # issue worktree
-example-app-wt/gemini-125-docs-followup/      # issue worktree
+example-app/                                      # main checkout
+example-app/.worktrees/codex-123-feature-slice/   # issue worktree
+example-app/.worktrees/claude-124-review-cleanup/ # issue worktree
+example-app/.worktrees/gemini-125-docs-followup/  # issue worktree
 ```
 
 The helper creates:
@@ -73,7 +85,22 @@ Use `--root` to place worktrees somewhere else:
 ```
 
 Relative `--root` paths are resolved from the main checkout, not your current
-directory.
+directory. `--root` overrides the `AGENT_VAULT_WORKTREE_ROOT` environment
+variable, which overrides the default `.worktrees/` root:
+
+```bash
+AGENT_VAULT_WORKTREE_ROOT=../custom-worktrees \
+  ./scripts/new-worktree.sh --agent codex --issue 126 --slug api-refactor
+```
+
+## Repo-Local Worktree Notes
+Git handles nested worktrees under `.worktrees/<name>/` cleanly; each nested
+worktree has a `.git` file that points back to Git's worktree metadata.
+Generated `.gitignore` management keeps `/.worktrees/` ignored so the main
+checkout's status stays clean.
+
+Tools that do not honor `.gitignore` may still traverse repo-local worktree
+contents. `rg` respects `.gitignore` by default.
 
 ## Agent Sandbox Permissions
 It is fine for an agent launched from the original checkout to run the setup
@@ -83,29 +110,26 @@ helper:
 ./scripts/new-worktree.sh --agent codex --issue 123 --slug feature-slice
 ```
 
-For actual writing work, launch a new agent session from inside the generated
-worktree:
+For actual writing work, switch to the generated worktree first:
 
 ```bash
-cd ../example-app-wt/codex-123-feature-slice
+cd .worktrees/codex-123-feature-slice
 codex
 ```
 
 Use the same pattern for other agents:
 
 ```bash
-cd ../example-app-wt/claude-124-review-cleanup
+cd .worktrees/claude-124-review-cleanup
 claude
 
-cd ../example-app-wt/gemini-125-docs-followup
+cd .worktrees/gemini-125-docs-followup
 gemini
 ```
 
 Many agent clients treat the launch directory as the active writable workspace.
-If an agent launched from the main checkout edits a sibling worktree, the client
-may ask for extra approval prompts or deny writes. If your client supports
-trusted or writable roots, you can trust the sibling worktree root, but launching
-inside the assigned worktree is the default path.
+If the agent cannot relaunch from the worktree, use the printed path for all
+subsequent file operations before making code edits.
 
 ## Recommended Workflow
 
@@ -118,7 +142,7 @@ inside the assigned worktree is the default path.
 ### 2. Enter the new directory
 
 ```bash
-cd ../example-app-wt/codex-123-feature-slice
+cd .worktrees/codex-123-feature-slice
 ```
 
 ### 3. Launch the writing agent
@@ -130,19 +154,52 @@ codex
 ### 4. Run issue-local checks from that worktree
 Run the relevant project commands from `agent-vault/project-commands.md`.
 
-### 5. After merge, remove the worktree from a safe directory
+## Cleanup After Merge Or Completion
+Post-merge cleanup is the standard cleanup point because the issue branch
+usually maps to the pull request.
+
+Before deleting the branch, verify the PR is merged:
+
+```bash
+gh pr view codex/123-feature-slice --json state,mergedAt
+```
+
+Only proceed with branch deletion when the PR is merged, or when the owner
+explicitly confirms that unmerged work is abandoned and the branch can be
+deleted. `OPEN`, `CLOSED` without `mergedAt`, missing PRs, stale activity, and
+unclear context all use the safe default: remove the worktree if appropriate,
+keep the branch, and report what was skipped.
+
 From the main checkout or another directory outside the target worktree:
 
 ```bash
+git fetch
+git checkout main
+git pull
 ./scripts/remove-worktree.sh --branch codex/123-feature-slice --delete-branch
 ```
 
-The cleanup helper refuses to remove a worktree containing the current working
-directory. This avoids leaving an agent session pointed at a deleted directory.
+If the project uses a non-`main` integration branch, use that project default
+instead.
 
-Only use `--delete-branch` after the issue branch is merged or no longer needed.
-Add `--force` only when you intentionally want to remove a dirty disposable
-worktree.
+For done-but-unmerged work, remove only the worktree unless the owner confirms
+branch deletion:
+
+```bash
+./scripts/remove-worktree.sh --branch codex/123-feature-slice
+```
+
+The cleanup helper refuses to remove a worktree containing the current working
+directory. If your current directory is inside the target worktree, switch to
+the main checkout or another safe directory before running cleanup.
+
+Treat helper refusal as a safety signal. If cleanup is blocked by the current
+working directory, a branch/path mismatch, or a shared `.venv` editable install
+that still points inside the target worktree, report the remaining cleanup step
+instead of forcing through.
+
+Do not run `--force` autonomously. It is a user-confirmed escape hatch for an
+intentionally disposable dirty worktree, not part of normal cleanup.
 
 ## Existing Project Command Snippet
 For existing projects whose `agent-vault/project-commands.md` predates these
@@ -165,12 +222,17 @@ the project commands:
 # After merge, remove the worktree from the main checkout or another safe cwd
 ./scripts/remove-worktree.sh --branch codex/123-feature-slice --delete-branch
 \`\`\`
+
+See `docs/runbooks/parallel-agent-worktrees.md` for the full worktree workflow,
+including branch-deletion guardrails and cleanup for done-but-unmerged work.
 ```
 
 ## Notes
 - The create helper is idempotent for the same agent, issue, and slug. If the
   worktree already exists, it prints the existing path instead of creating a
   duplicate.
+- Existing sibling or custom worktree roots keep working with `--root` or
+  `AGENT_VAULT_WORKTREE_ROOT`; no automatic relocation is attempted.
 - The remove helper checks whether the main checkout's `.venv` has an editable
   install path pointing inside the target worktree. If so, it refuses removal so
   local tools do not keep importing from a deleted path.

--- a/scaffold/root/scripts/new-worktree.sh
+++ b/scaffold/root/scripts/new-worktree.sh
@@ -11,8 +11,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
-REPO_NAME="$(basename "$PROJECT_DIR")"
-DEFAULT_ROOT="$(dirname "$PROJECT_DIR")/${REPO_NAME}-wt"
+DEFAULT_ROOT="${PROJECT_DIR}/.worktrees"
 
 usage() {
     cat <<EOF
@@ -27,7 +26,11 @@ Options:
   --base REF     Optional base ref. Defaults to origin/main when available,
                  otherwise main, otherwise the current branch.
   --root DIR     Optional worktree root. Relative paths are resolved from the
-                 current repo root. Default: $DEFAULT_ROOT
+                 current repo root. Overrides AGENT_VAULT_WORKTREE_ROOT.
+                 Default: $DEFAULT_ROOT
+  AGENT_VAULT_WORKTREE_ROOT
+                 Optional environment default for the worktree root. Relative
+                 paths are resolved from the current repo root.
   -h, --help     Show this help
 
 Examples:
@@ -136,7 +139,7 @@ AGENT=""
 ISSUE=""
 SLUG=""
 BASE_REF=""
-ROOT_DIR="$DEFAULT_ROOT"
+ROOT_DIR="${AGENT_VAULT_WORKTREE_ROOT:-$DEFAULT_ROOT}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/scaffold/root/scripts/remove-worktree.sh
+++ b/scaffold/root/scripts/remove-worktree.sh
@@ -2,6 +2,7 @@
 # agent-vault-managed: helper-script; file=remove-worktree.sh
 
 # Safely remove one issue-scoped git worktree created for an agent session.
+# Run from the main checkout or another directory outside the target worktree.
 
 set -euo pipefail
 
@@ -19,14 +20,16 @@ Options:
   --path DIR        Worktree path to remove. Relative paths are resolved from
                     the current repo root.
   --delete-branch   Delete the local branch with git branch -D after removal.
-                    Use only after the PR is merged or the branch is disposable.
-  --force           Pass --force to git worktree remove.
+                    Use only after verifying the PR is merged or after owner
+                    confirmation that the branch is disposable.
+  --force           Pass --force to git worktree remove. Use only after owner
+                    confirmation for an intentionally disposable dirty worktree.
   -h, --help        Show this help
 
 Examples:
   $0 --branch codex/123-feature-slice
   $0 --branch codex/123-feature-slice --delete-branch
-  $0 --path ../example-app-wt/codex-123-feature-slice --force
+  $0 --path .worktrees/codex-123-feature-slice --force
 EOF
 }
 

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -134,6 +134,7 @@ MANAGED_GITIGNORE_BLOCKS=(
   $'# Obsidian -- machine-specific & volatile files (ignore these)\n.obsidian/workspace.json\n.obsidian/app.json\n.obsidian/appearance.json\n.obsidian/workspace-mobile.json\n.obsidian/cache/\n.obsidian/backup/'
   $'# Plugin data (can contain API keys or large caches)\n.obsidian/plugins/*/data.json'
   $'# Agent Vault -- local sync and migration backups (ignore these)\n/agent-vault/context/updates/'
+  $'# Agent Vault -- local worktrees (ignore these)\n/.worktrees/'
 )
 
 ROOT_AGENTS_MARKER="<!-- agent-vault-managed: root-wrapper; file=AGENTS.md -->"

--- a/scripts/test-gitignore-management.sh
+++ b/scripts/test-gitignore-management.sh
@@ -132,6 +132,8 @@ write_managed_gitignore() {
 .obsidian/plugins/*/data.json
 # Agent Vault -- local sync and migration backups (ignore these)
 /agent-vault/context/updates/
+# Agent Vault -- local worktrees (ignore these)
+/.worktrees/
 EOF
 }
 
@@ -156,17 +158,27 @@ assert_grouped_partial_block_insert() {
   assert_line_count "$file_path" ".obsidian/app.json" 1
 }
 
+assert_managed_worktree_ignore() {
+  local file_path="$1"
+
+  assert_has_line "$file_path" "# Agent Vault -- local worktrees (ignore these)"
+  assert_has_line "$file_path" "/.worktrees/"
+  assert_line_count "$file_path" "/.worktrees/" 1
+}
+
 new_project_repo="$tmp_root/new-project-existing-patterns"
 init_repo "$new_project_repo"
 write_legacy_gitignore "$new_project_repo"
 "$repo_root/scripts/new-project.sh" "gitignore-test" "$new_project_repo" >/dev/null
 assert_no_dangling_comment_append "$new_project_repo/.gitignore"
+assert_managed_worktree_ignore "$new_project_repo/.gitignore"
 
 new_project_partial_repo="$tmp_root/new-project-partial-patterns"
 init_repo "$new_project_partial_repo"
 write_partial_obsidian_gitignore "$new_project_partial_repo"
 "$repo_root/scripts/new-project.sh" "gitignore-test" "$new_project_partial_repo" >/dev/null
 assert_grouped_partial_block_insert "$new_project_partial_repo/.gitignore"
+assert_managed_worktree_ignore "$new_project_partial_repo/.gitignore"
 
 new_project_managed_repo="$tmp_root/new-project-managed-patterns"
 init_repo "$new_project_managed_repo"
@@ -175,6 +187,7 @@ new_project_output="$("$repo_root/scripts/new-project.sh" "gitignore-test" "$new
 assert_output_not_contains "$new_project_output" "unbound variable"
 assert_output_not_contains "$new_project_output" "missing_lines[@]"
 assert_has_line "$new_project_managed_repo/.gitignore" "# Agent Vault -- local sync and migration backups (ignore these)"
+assert_managed_worktree_ignore "$new_project_managed_repo/.gitignore"
 
 update_project_repo="$tmp_root/update-project-existing-patterns"
 init_repo "$update_project_repo"
@@ -182,6 +195,7 @@ init_repo "$update_project_repo"
 write_legacy_gitignore "$update_project_repo"
 "$repo_root/scripts/update-project.sh" "$update_project_repo" >/dev/null
 assert_no_dangling_comment_append "$update_project_repo/.gitignore"
+assert_managed_worktree_ignore "$update_project_repo/.gitignore"
 
 update_project_partial_repo="$tmp_root/update-project-partial-patterns"
 init_repo "$update_project_partial_repo"
@@ -189,6 +203,7 @@ init_repo "$update_project_partial_repo"
 write_partial_obsidian_gitignore "$update_project_partial_repo"
 "$repo_root/scripts/update-project.sh" "$update_project_partial_repo" >/dev/null
 assert_grouped_partial_block_insert "$update_project_partial_repo/.gitignore"
+assert_managed_worktree_ignore "$update_project_partial_repo/.gitignore"
 
 update_project_managed_repo="$tmp_root/update-project-managed-patterns"
 init_repo "$update_project_managed_repo"
@@ -198,5 +213,6 @@ update_project_output="$("$repo_root/scripts/update-project.sh" "$update_project
 assert_output_not_contains "$update_project_output" "unbound variable"
 assert_output_not_contains "$update_project_output" "missing_lines[@]"
 assert_has_line "$update_project_managed_repo/.gitignore" "# Agent Vault -- local sync and migration backups (ignore these)"
+assert_managed_worktree_ignore "$update_project_managed_repo/.gitignore"
 
 echo "gitignore management regression checks passed."

--- a/scripts/test-new-worktree.sh
+++ b/scripts/test-new-worktree.sh
@@ -120,7 +120,70 @@ run_new_worktree() {
   bash "$working/scripts/new-worktree.sh" --root "$tmp_root/wt" "$@"
 }
 
-# --- Test 1: Create a new worktree with explicit slug ---
+run_new_worktree_default() {
+  local working="$1"
+  shift
+
+  bash "$working/scripts/new-worktree.sh" "$@"
+}
+
+run_new_worktree_with_env_root() {
+  local working="$1"
+  local root="$2"
+  shift 2
+
+  AGENT_VAULT_WORKTREE_ROOT="$root" bash "$working/scripts/new-worktree.sh" "$@"
+}
+
+# --- Test 1: Default root is repo-local .worktrees and remains idempotent ---
+working="$(setup_repo repo-default-root)"
+rc=0
+output="$(run_new_worktree_default "$working" --agent codex --issue 130 --slug default-root 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "default-root exits 0"
+expected_path="$working/.worktrees/codex-130-default-root"
+assert_path_exists "$expected_path" "default-root created target path"
+assert_path_under_tmp "$expected_path" "default-root stays inside temp root"
+assert_output_contains "$output" "cd $expected_path" "default-root prints cd hint"
+rc=0
+output="$(run_new_worktree_default "$working" --agent codex --issue 130 --slug default-root 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "default-root rerun exits 0"
+assert_output_contains "$output" "Worktree already exists:" "default-root rerun reports existing path"
+assert_output_contains "$output" "$expected_path" "default-root rerun prints existing path"
+
+# --- Test 2: Environment root is honored and relative paths resolve from repo root ---
+working="$(setup_repo repo-env-root)"
+rc=0
+output="$(run_new_worktree_with_env_root "$working" "env-wt" --agent codex --issue 131 --slug env-root 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "env-root exits 0"
+expected_path="$working/env-wt/codex-131-env-root"
+assert_path_exists "$expected_path" "env-root created target path"
+assert_path_under_tmp "$expected_path" "env-root stays inside temp root"
+assert_output_contains "$output" "cd $expected_path" "env-root prints cd hint"
+
+# --- Test 3: --root wins over AGENT_VAULT_WORKTREE_ROOT ---
+working="$(setup_repo repo-root-precedence)"
+override_root="$tmp_root/root-override"
+rc=0
+output="$(run_new_worktree_with_env_root "$working" "env-wt" --root "$override_root" --agent codex --issue 132 --slug root-wins 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "root-precedence exits 0"
+expected_path="$override_root/codex-132-root-wins"
+assert_path_exists "$expected_path" "root-precedence created target path"
+assert_path_under_tmp "$expected_path" "root-precedence stays inside temp root"
+assert_output_contains "$output" "cd $expected_path" "root-precedence prints cd hint"
+assert_path_missing "$working/env-wt/codex-132-root-wins" "root-precedence does not use env root"
+
+# --- Test 4: Invoking from a subdirectory still resolves defaults from repo root ---
+working="$(setup_repo repo-subdir-invoke)"
+mkdir -p "$working/nested"
+rc=0
+output="$(cd "$working/nested" && bash ../scripts/new-worktree.sh --agent codex --issue 133 --slug subdir-invoke 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "subdir-invoke exits 0"
+expected_path="$working/.worktrees/codex-133-subdir-invoke"
+assert_path_exists "$expected_path" "subdir-invoke created target path"
+assert_path_under_tmp "$expected_path" "subdir-invoke stays inside temp root"
+assert_output_contains "$output" "cd $expected_path" "subdir-invoke prints cd hint"
+
+# --- Test 5: Create a new worktree with explicit slug ---
 working="$(setup_repo repo1)"
 rc=0
 output="$(run_new_worktree "$working" --agent codex --issue 123 --slug feature-slice 2>&1)" || rc=$?
@@ -140,14 +203,14 @@ assert_output_contains "$output" "Created worktree:" "create-worktree reports cr
 assert_output_contains "$output" "cd $expected_path" "create-worktree prints cd hint"
 assert_output_contains "$output" "codex" "create-worktree prints codex hint"
 
-# --- Test 2: Re-running the same command is idempotent ---
+# --- Test 6: Re-running the same command is idempotent ---
 rc=0
 output="$(run_new_worktree "$working" --agent codex --issue 123 --slug feature-slice 2>&1)" || rc=$?
 assert_exit_code 0 "$rc" "recreate-worktree exits 0"
 assert_output_contains "$output" "Worktree already exists:" "recreate-worktree reports existing path"
 assert_output_contains "$output" "$expected_path" "recreate-worktree prints existing path"
 
-# --- Test 3: Agent and slug values are normalized ---
+# --- Test 7: Agent and slug values are normalized ---
 working="$(setup_repo repo2)"
 rc=0
 output="$(run_new_worktree "$working" --agent "Claude Code" --issue 124 --slug "Review Cleanup" 2>&1)" || rc=$?
@@ -165,14 +228,14 @@ else
 fi
 assert_output_contains "$output" "claude" "normalized-worktree prints claude hint"
 
-# --- Test 4: Gemini launch hint is supported ---
+# --- Test 8: Gemini launch hint is supported ---
 working="$(setup_repo repo3)"
 rc=0
 output="$(run_new_worktree "$working" --agent gemini --issue 125 --slug docs-followup 2>&1)" || rc=$?
 assert_exit_code 0 "$rc" "gemini-worktree exits 0"
 assert_output_contains "$output" "gemini" "gemini-worktree prints gemini hint"
 
-# --- Test 5: Stale worktree metadata is pruned and recreated ---
+# --- Test 9: Stale worktree metadata is pruned and recreated ---
 working="$(setup_repo repo4)"
 rc=0
 output="$(run_new_worktree "$working" --agent codex --issue 126 --slug stale-recreate 2>&1)" || rc=$?
@@ -186,26 +249,26 @@ assert_exit_code 0 "$rc" "stale-worktree recreate exits 0"
 assert_output_contains "$output" "Created worktree:" "stale-worktree rerun recreates path"
 assert_path_exists "$expected_path" "stale-worktree recreated target path"
 
-# --- Test 6: Missing required args fail clearly ---
+# --- Test 10: Missing required args fail clearly ---
 working="$(setup_repo repo5)"
 rc=0
 output="$(run_new_worktree "$working" --agent codex 2>&1)" || rc=$?
 assert_exit_code 1 "$rc" "missing-issue exits 1"
 assert_output_contains "$output" "--issue is required" "missing-issue shows error"
 
-# --- Test 7: Invalid issue values fail clearly ---
+# --- Test 11: Invalid issue values fail clearly ---
 rc=0
 output="$(run_new_worktree "$working" --agent codex --issue abc 2>&1)" || rc=$?
 assert_exit_code 1 "$rc" "non-numeric-issue exits 1"
 assert_output_contains "$output" "--issue must be numeric" "non-numeric-issue shows error"
 
-# --- Test 8: Agent values that normalize to empty fail clearly ---
+# --- Test 12: Agent values that normalize to empty fail clearly ---
 rc=0
 output="$(run_new_worktree "$working" --agent "!!!" --issue 127 2>&1)" || rc=$?
 assert_exit_code 1 "$rc" "empty-normalized-agent exits 1"
 assert_output_contains "$output" "--agent must contain letters or numbers" "empty-normalized-agent shows error"
 
-# --- Test 9: Bad base refs fail before creating the worktree root ---
+# --- Test 13: Bad base refs fail before creating the worktree root ---
 working="$(setup_repo repo6)"
 bad_base_root="$tmp_root/bad-base-root"
 rc=0

--- a/scripts/test-worktree-helper-sync.sh
+++ b/scripts/test-worktree-helper-sync.sh
@@ -121,6 +121,10 @@ assert_executable "$target/scripts/new-worktree.sh" "new-project makes new-workt
 assert_executable "$target/scripts/remove-worktree.sh" "new-project makes remove-worktree executable"
 assert_file_contains "$target/scripts/new-worktree.sh" "# agent-vault-managed: helper-script; file=new-worktree.sh" "new-project seeds new-worktree marker"
 assert_file_contains "$target/scripts/remove-worktree.sh" "# agent-vault-managed: helper-script; file=remove-worktree.sh" "new-project seeds remove-worktree marker"
+assert_file_contains "$target/scripts/new-worktree.sh" 'DEFAULT_ROOT="${PROJECT_DIR}/.worktrees"' "new-project seeds repo-local worktree default"
+assert_file_contains "$target/scripts/new-worktree.sh" "AGENT_VAULT_WORKTREE_ROOT" "new-project seeds env worktree override"
+assert_file_contains "$target/scripts/remove-worktree.sh" "Use only after verifying the PR is merged" "new-project seeds guarded remove-worktree guidance"
+assert_file_contains "$target/docs/runbooks/parallel-agent-worktrees.md" "Cleanup After Merge Or Completion" "new-project seeds cleanup runbook"
 
 # --- Test 2: update-project creates missing helpers in existing vaults ---
 target="$(setup_empty_repo update-missing-target)"
@@ -133,6 +137,8 @@ assert_output_contains "$output" "Created: scripts/new-worktree.sh" "update-proj
 assert_output_contains "$output" "Created: scripts/remove-worktree.sh" "update-project reports remove-worktree creation"
 assert_executable "$target/scripts/new-worktree.sh" "update-project makes new-worktree executable"
 assert_executable "$target/scripts/remove-worktree.sh" "update-project makes remove-worktree executable"
+assert_file_contains "$target/scripts/new-worktree.sh" 'DEFAULT_ROOT="${PROJECT_DIR}/.worktrees"' "update-project creates new helper with repo-local default"
+assert_file_contains "$target/scripts/remove-worktree.sh" "Use only after verifying the PR is merged" "update-project creates remove helper with guarded guidance"
 
 # --- Test 3: update-project skips unmanaged helper scripts by default ---
 target="$(setup_empty_repo unmanaged-skip-target)"
@@ -173,13 +179,23 @@ run_new_project "$target" >/dev/null
   printf '%s\n' '# agent-vault-managed: helper-script; file=new-worktree.sh'
   printf '%s\n' 'echo stale managed helper'
 } > "$target/scripts/new-worktree.sh"
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' '# agent-vault-managed: helper-script; file=remove-worktree.sh'
+  printf '%s\n' 'echo stale managed remove helper'
+} > "$target/scripts/remove-worktree.sh"
 chmod -x "$target/scripts/new-worktree.sh"
+chmod -x "$target/scripts/remove-worktree.sh"
 rc=0
 output="$(run_update_project "$target" 2>&1)" || rc=$?
 assert_exit_code 0 "$rc" "update-project managed-refresh exits 0"
 assert_output_contains "$output" "Updated: scripts/new-worktree.sh" "update-project reports managed helper update"
+assert_output_contains "$output" "Updated: scripts/remove-worktree.sh" "update-project reports managed remove helper update"
 assert_file_contains "$target/scripts/new-worktree.sh" "Create or reuse one issue-scoped worktree" "update-project refreshes managed helper content"
+assert_file_contains "$target/scripts/new-worktree.sh" 'DEFAULT_ROOT="${PROJECT_DIR}/.worktrees"' "update-project refreshes new helper default"
+assert_file_contains "$target/scripts/remove-worktree.sh" "Use only after verifying the PR is merged" "update-project refreshes remove helper guidance"
 assert_executable "$target/scripts/new-worktree.sh" "update-project fixes managed helper executable bit"
+assert_executable "$target/scripts/remove-worktree.sh" "update-project fixes managed remove helper executable bit"
 
 # --- Test 6: runbook is seed-only after creation ---
 target="$(setup_empty_repo runbook-seed-target)"

--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -44,6 +44,7 @@ MANAGED_GITIGNORE_BLOCKS=(
   $'# Obsidian -- machine-specific & volatile files (ignore these)\n.obsidian/workspace.json\n.obsidian/app.json\n.obsidian/appearance.json\n.obsidian/workspace-mobile.json\n.obsidian/cache/\n.obsidian/backup/'
   $'# Plugin data (can contain API keys or large caches)\n.obsidian/plugins/*/data.json'
   $'# Agent Vault -- local sync and migration backups (ignore these)\n/agent-vault/context/updates/'
+  $'# Agent Vault -- local worktrees (ignore these)\n/.worktrees/'
 )
 
 ROOT_AGENTS_MARKER="<!-- agent-vault-managed: root-wrapper; file=AGENTS.md -->"


### PR DESCRIPTION
Addresses #98.

## Summary

This changes generated managed worktrees to default to a repo-local ignored `.worktrees/` root instead of a sibling directory. The create helper now also supports `AGENT_VAULT_WORKTREE_ROOT`, while `--root` remains the explicit highest-precedence override.

The generated agent guidance now requires implementation agents to create/reuse an issue-scoped worktree before code edits, switch to the printed worktree path for all writes, and clean up worktrees after merge or when issue work is done. The full cleanup recipe lives in the runbook, with shorter policy pointers in generated agent instructions.

## Files / Areas Changed

- `scaffold/root/scripts/new-worktree.sh`: default root is `$PROJECT_DIR/.worktrees`; added `AGENT_VAULT_WORKTREE_ROOT` support.
- `scaffold/root/scripts/remove-worktree.sh`: updated help text for safe cwd, merge verification, owner confirmation, and guarded `--force` usage.
- `scripts/new-project.sh`, `scripts/update-project.sh`: managed `.gitignore` entries now include anchored `/.worktrees/`.
- `scaffold/root/docs/runbooks/parallel-agent-worktrees.md`: updated canonical create/start/cleanup workflow.
- `scaffold/agent-vault/AGENTS.md`, `scaffold/agent-vault/shared-rules.md`, `scaffold/agent-vault/project-commands.md`: added generated agent worktree start and cleanup contract.
- `README.md`: updated template-maintainer documentation for the new generated behavior.
- Regression tests: expanded coverage for default root, env/root precedence, generated `.gitignore`, helper sync, and cleanup guidance.

## Verification Loop

Passed:

- `bash scripts/test-new-worktree.sh`
- `bash scripts/test-gitignore-management.sh`
- `bash scripts/test-worktree-helper-sync.sh`
- `bash scripts/test-remove-worktree.sh`
- `bash scripts/test-main-push-gate.sh`
- `bash scripts/test-session-metadata-hook.sh`
- `bash scripts/test-coding-standards-sync.sh`
- `bash scripts/test-decision-template-sync.sh`
- `bash scripts/check-policy-mirrors.sh`
- `git diff --check`
- `rg -n "\.\.\/<repo-name>-wt|<repo-name>-wt|example-app-wt|sibling worktrees|sibling directory named|sibling directory" scaffold README.md scripts` returned no matches.

Skipped / unavailable:

- ShellCheck was not installed in the local environment, so no separate shell lint pass ran. Follow-up tracked separately in #99.

## Risks / Rollback

- Existing generated projects with managed helper scripts will get the new default when synced. Existing sibling/custom worktrees keep working through `--root` or `AGENT_VAULT_WORKTREE_ROOT`; no automatic relocation is attempted.
- Cleanup guidance now documents stronger branch-deletion guardrails, but the helper still relies on users/agents to verify PR merge state before passing `--delete-branch`.
- Rollback is straightforward: revert this commit to restore sibling-root defaults and previous generated guidance.

## Docs Consistency

Updated `README.md`, generated runbook guidance, generated command docs, and mirrored generated agent workflow rules. `bash scripts/check-policy-mirrors.sh` passed.