### PR TITLE
Add shell style checks

### DIFF
--- a/.github/workflows/scaffold-regression-checks.yml
+++ b/.github/workflows/scaffold-regression-checks.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/test-decision-template-sync.sh"
       - "scripts/test-session-metadata-hook.sh"
       - "scripts/test-main-push-gate.sh"
+      - "scripts/test-path-expansion.sh"
       - "scripts/test-new-worktree.sh"
       - "scripts/test-remove-worktree.sh"
       - "scripts/test-worktree-helper-sync.sh"
@@ -33,6 +34,7 @@ on:
       - "scripts/test-decision-template-sync.sh"
       - "scripts/test-session-metadata-hook.sh"
       - "scripts/test-main-push-gate.sh"
+      - "scripts/test-path-expansion.sh"
       - "scripts/test-new-worktree.sh"
       - "scripts/test-remove-worktree.sh"
       - "scripts/test-worktree-helper-sync.sh"
@@ -55,6 +57,8 @@ jobs:
         run: bash scripts/test-session-metadata-hook.sh
       - name: Verify main push metadata gate
         run: bash scripts/test-main-push-gate.sh
+      - name: Verify path expansion handling
+        run: bash scripts/test-path-expansion.sh
       - name: Verify worktree creation helper
         run: bash scripts/test-new-worktree.sh
       - name: Verify worktree removal helper

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -1,0 +1,61 @@
+name: Style Check
+
+on:
+  pull_request:
+    paths:
+      - "README.md"
+      - "scripts/**"
+      - "scaffold/root/scripts/**"
+      - "scaffold/agent-vault/_assets/hooks/**"
+      - ".github/workflows/style-check.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "README.md"
+      - "scripts/**"
+      - "scaffold/root/scripts/**"
+      - "scaffold/agent-vault/_assets/hooks/**"
+      - ".github/workflows/style-check.yml"
+  workflow_dispatch:
+
+jobs:
+  shell-style:
+    runs-on: ubuntu-latest
+    env:
+      # Pinned so ShellCheck rule changes and shfmt formatting changes are
+      # intentional maintenance bumps rather than runner-image drift.
+      SHELLCHECK_VERSION: v0.11.0
+      SHFMT_VERSION: v3.13.1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pinned shell style tools
+        run: |
+          set -euo pipefail
+
+          tools_dir="$RUNNER_TEMP/shell-style-tools"
+          bin_dir="$tools_dir/bin"
+          mkdir -p "$bin_dir"
+
+          curl -fsSL \
+            -o "$tools_dir/shellcheck.tar.xz" \
+            "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          tar -C "$tools_dir" -xf "$tools_dir/shellcheck.tar.xz"
+          install -m 0755 "$tools_dir/shellcheck-${SHELLCHECK_VERSION}/shellcheck" "$bin_dir/shellcheck"
+
+          curl -fsSL \
+            -o "$bin_dir/shfmt" \
+            "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_amd64"
+          chmod +x "$bin_dir/shfmt"
+
+          echo "$bin_dir" >> "$GITHUB_PATH"
+
+      - name: Show tool versions
+        run: |
+          shellcheck --version
+          shfmt --version
+
+      - name: Run shell style checks
+        run: bash scripts/check-style.sh

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -27,6 +27,8 @@ jobs:
       # intentional maintenance bumps rather than runner-image drift.
       SHELLCHECK_VERSION: v0.11.0
       SHFMT_VERSION: v3.13.1
+      SHELLCHECK_SHA256: 8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
+      SHFMT_SHA256: fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,12 +44,14 @@ jobs:
           curl -fsSL \
             -o "$tools_dir/shellcheck.tar.xz" \
             "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          printf '%s  %s\n' "$SHELLCHECK_SHA256" "$tools_dir/shellcheck.tar.xz" | sha256sum -c -
           tar -C "$tools_dir" -xf "$tools_dir/shellcheck.tar.xz"
           install -m 0755 "$tools_dir/shellcheck-${SHELLCHECK_VERSION}/shellcheck" "$bin_dir/shellcheck"
 
           curl -fsSL \
             -o "$bin_dir/shfmt" \
             "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_amd64"
+          printf '%s  %s\n' "$SHFMT_SHA256" "$bin_dir/shfmt" | sha256sum -c -
           chmod +x "$bin_dir/shfmt"
 
           echo "$bin_dir" >> "$GITHUB_PATH"

--- a/README.md
+++ b/README.md
@@ -105,9 +105,17 @@ For local formatting, run:
 Local runs require ShellCheck and shfmt. On macOS, install them with:
 - `brew install shellcheck shfmt`
 
+On Ubuntu, install ShellCheck from apt and shfmt from the same pinned release
+family CI uses:
+- `sudo apt-get update && sudo apt-get install -y shellcheck`
+- `curl -fsSL -o shfmt https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64`
+- `mkdir -p "$HOME/.local/bin"`
+- `install -m 0755 shfmt "$HOME/.local/bin/shfmt"`
+
 CI installs pinned release binaries instead of relying on runner image versions:
 - ShellCheck `v0.11.0`
 - shfmt `v3.13.1`
+and verifies both downloads with pinned SHA-256 digests.
 
 CI runs the same command via `.github/workflows/style-check.yml`.
 
@@ -118,6 +126,7 @@ Run the scaffold regression scripts locally when changing bootstrap, sync, or tr
 - `bash scripts/test-decision-template-sync.sh`
 - `bash scripts/test-session-metadata-hook.sh`
 - `bash scripts/test-main-push-gate.sh`
+- `bash scripts/test-path-expansion.sh`
 - `bash scripts/test-new-worktree.sh`
 - `bash scripts/test-remove-worktree.sh`
 - `bash scripts/test-worktree-helper-sync.sh`

--- a/README.md
+++ b/README.md
@@ -89,6 +89,28 @@ To prevent accidental drift, run:
 
 CI also enforces this via `.github/workflows/policy-mirror-check.yml` on pull requests and pushes to `main`.
 
+## Style Checks
+Run shell style/static checks before pull requests that touch scripts, generated
+root helper scripts, or tracked hook assets:
+- `bash scripts/check-style.sh`
+
+The command checks the tracked shell surface with:
+- `bash -n` syntax validation
+- `shellcheck --severity=warning -x`
+- `shfmt -i 2 -ci -d`
+
+For local formatting, run:
+- `bash scripts/check-style.sh --fix`
+
+Local runs require ShellCheck and shfmt. On macOS, install them with:
+- `brew install shellcheck shfmt`
+
+CI installs pinned release binaries instead of relying on runner image versions:
+- ShellCheck `v0.11.0`
+- shfmt `v3.13.1`
+
+CI runs the same command via `.github/workflows/style-check.yml`.
+
 ## Scaffold Regression Checks
 Run the scaffold regression scripts locally when changing bootstrap, sync, or tracked hook behavior:
 - `bash scripts/test-gitignore-management.sh`

--- a/scaffold/agent-vault/_assets/hooks/lib/runtime-note.sh
+++ b/scaffold/agent-vault/_assets/hooks/lib/runtime-note.sh
@@ -4,7 +4,7 @@ is_runtime_note_file() {
   local file_path="$1"
 
   case "$file_path" in
-    agent-vault/context-log.md|agent-vault/open-questions.md|agent-vault/decision-log.md|agent-vault/lessons.md)
+    agent-vault/context-log.md | agent-vault/open-questions.md | agent-vault/decision-log.md | agent-vault/lessons.md)
       return 0
       ;;
     agent-vault/daily/*.md)

--- a/scaffold/agent-vault/_assets/hooks/pre-push
+++ b/scaffold/agent-vault/_assets/hooks/pre-push
@@ -66,7 +66,7 @@ collect_commit_changed_files() {
   fi
 }
 
-while read -r local_ref local_sha remote_ref remote_sha; do
+while read -r _local_ref local_sha remote_ref remote_sha; do
   [[ "$remote_ref" == "refs/heads/main" ]] || continue
 
   if [[ "$local_sha" == "$zero_sha" ]]; then

--- a/scaffold/root/scripts/new-worktree.sh
+++ b/scaffold/root/scripts/new-worktree.sh
@@ -14,7 +14,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 DEFAULT_ROOT="${PROJECT_DIR}/.worktrees"
 
 usage() {
-    cat <<EOF
+  cat <<EOF
 Usage: $0 --agent NAME --issue NUMBER [--slug TEXT] [--base REF] [--root DIR]
 
 Create or reuse one issue-scoped worktree for one writing agent.
@@ -41,98 +41,98 @@ EOF
 }
 
 die() {
-    echo "Error: $*" >&2
-    exit 1
+  echo "Error: $*" >&2
+  exit 1
 }
 
 normalize_token() {
-    local raw="$1"
-    printf '%s' "$raw" \
-        | tr '[:upper:]' '[:lower:]' \
-        | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g'
+  local raw="$1"
+  printf '%s' "$raw" |
+    tr '[:upper:]' '[:lower:]' |
+    sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g'
 }
 
 resolve_root_dir() {
-    local raw="$1"
-    if [[ "$raw" = /* ]]; then
-        printf '%s\n' "$raw"
-    else
-        printf '%s\n' "$PROJECT_DIR/$raw"
-    fi
+  local raw="$1"
+  if [[ "$raw" = /* ]]; then
+    printf '%s\n' "$raw"
+  else
+    printf '%s\n' "$PROJECT_DIR/$raw"
+  fi
 }
 
 default_base_ref() {
-    if git -C "$PROJECT_DIR" rev-parse --verify --quiet "refs/remotes/origin/main" >/dev/null; then
-        printf 'origin/main\n'
-        return
-    fi
-    if git -C "$PROJECT_DIR" rev-parse --verify --quiet "refs/heads/main" >/dev/null; then
-        printf 'main\n'
-        return
-    fi
-    git -C "$PROJECT_DIR" branch --show-current
+  if git -C "$PROJECT_DIR" rev-parse --verify --quiet "refs/remotes/origin/main" >/dev/null; then
+    printf 'origin/main\n'
+    return
+  fi
+  if git -C "$PROJECT_DIR" rev-parse --verify --quiet "refs/heads/main" >/dev/null; then
+    printf 'main\n'
+    return
+  fi
+  git -C "$PROJECT_DIR" branch --show-current
 }
 
 find_branch_worktree() {
-    local branch_name="$1"
-    local current_worktree=""
-    local line=""
+  local branch_name="$1"
+  local current_worktree=""
+  local line=""
 
-    while IFS= read -r line; do
-        case "$line" in
-            worktree\ *)
-                current_worktree="${line#worktree }"
-                ;;
-            branch\ refs/heads/*)
-                if [[ "${line#branch refs/heads/}" == "$branch_name" ]]; then
-                    printf '%s\n' "$current_worktree"
-                    return 0
-                fi
-                ;;
-        esac
-    done < <(git -C "$PROJECT_DIR" worktree list --porcelain)
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *)
+        current_worktree="${line#worktree }"
+        ;;
+      branch\ refs/heads/*)
+        if [[ "${line#branch refs/heads/}" == "$branch_name" ]]; then
+          printf '%s\n' "$current_worktree"
+          return 0
+        fi
+        ;;
+    esac
+  done < <(git -C "$PROJECT_DIR" worktree list --porcelain)
 
-    return 1
+  return 1
 }
 
 launch_hint() {
-    local normalized_agent="$1"
-    case "$normalized_agent" in
-        codex*)
-            printf 'codex\n'
-            ;;
-        claude*|claude-code*)
-            printf 'claude\n'
-            ;;
-        gemini*)
-            printf 'gemini\n'
-            ;;
-        *)
-            printf '\n'
-            ;;
-    esac
+  local normalized_agent="$1"
+  case "$normalized_agent" in
+    codex*)
+      printf 'codex\n'
+      ;;
+    claude*)
+      printf 'claude\n'
+      ;;
+    gemini*)
+      printf 'gemini\n'
+      ;;
+    *)
+      printf '\n'
+      ;;
+  esac
 }
 
 print_next_steps() {
-    local worktree_path="$1"
-    local normalized_agent="$2"
-    local hint
+  local worktree_path="$1"
+  local normalized_agent="$2"
+  local hint
 
-    hint="$(launch_hint "$normalized_agent")"
+  hint="$(launch_hint "$normalized_agent")"
 
-    echo ""
-    echo "Next:"
-    echo "  cd $worktree_path"
-    if [[ -n "$hint" ]]; then
-        echo "  $hint"
-    else
-        echo "  # launch your writing agent from this directory"
-    fi
+  echo ""
+  echo "Next:"
+  echo "  cd $worktree_path"
+  if [[ -n "$hint" ]]; then
+    echo "  $hint"
+  else
+    echo "  # launch your writing agent from this directory"
+  fi
 }
 
 require_git_repo() {
-    git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
-        || die "Not inside a git worktree: $PROJECT_DIR"
+  git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
+    die "Not inside a git worktree: $PROJECT_DIR"
 }
 
 AGENT=""
@@ -142,40 +142,40 @@ BASE_REF=""
 ROOT_DIR="${AGENT_VAULT_WORKTREE_ROOT:-$DEFAULT_ROOT}"
 
 while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --agent)
-            [[ $# -ge 2 ]] || die "Missing value for --agent"
-            AGENT="$2"
-            shift 2
-            ;;
-        --issue)
-            [[ $# -ge 2 ]] || die "Missing value for --issue"
-            ISSUE="$2"
-            shift 2
-            ;;
-        --slug)
-            [[ $# -ge 2 ]] || die "Missing value for --slug"
-            SLUG="$2"
-            shift 2
-            ;;
-        --base)
-            [[ $# -ge 2 ]] || die "Missing value for --base"
-            BASE_REF="$2"
-            shift 2
-            ;;
-        --root)
-            [[ $# -ge 2 ]] || die "Missing value for --root"
-            ROOT_DIR="$2"
-            shift 2
-            ;;
-        -h|--help)
-            usage
-            exit 0
-            ;;
-        *)
-            die "Unknown option: $1"
-            ;;
-    esac
+  case "$1" in
+    --agent)
+      [[ $# -ge 2 ]] || die "Missing value for --agent"
+      AGENT="$2"
+      shift 2
+      ;;
+    --issue)
+      [[ $# -ge 2 ]] || die "Missing value for --issue"
+      ISSUE="$2"
+      shift 2
+      ;;
+    --slug)
+      [[ $# -ge 2 ]] || die "Missing value for --slug"
+      SLUG="$2"
+      shift 2
+      ;;
+    --base)
+      [[ $# -ge 2 ]] || die "Missing value for --base"
+      BASE_REF="$2"
+      shift 2
+      ;;
+    --root)
+      [[ $# -ge 2 ]] || die "Missing value for --root"
+      ROOT_DIR="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1"
+      ;;
+  esac
 done
 
 require_git_repo
@@ -189,13 +189,13 @@ NORMALIZED_AGENT="$(normalize_token "$AGENT")"
 
 NORMALIZED_SLUG=""
 if [[ -n "$SLUG" ]]; then
-    NORMALIZED_SLUG="$(normalize_token "$SLUG")"
-    [[ -n "$NORMALIZED_SLUG" ]] || die "--slug must contain letters or numbers"
+  NORMALIZED_SLUG="$(normalize_token "$SLUG")"
+  [[ -n "$NORMALIZED_SLUG" ]] || die "--slug must contain letters or numbers"
 fi
 
 NAME_SUFFIX="$ISSUE"
 if [[ -n "$NORMALIZED_SLUG" ]]; then
-    NAME_SUFFIX="${NAME_SUFFIX}-${NORMALIZED_SLUG}"
+  NAME_SUFFIX="${NAME_SUFFIX}-${NORMALIZED_SLUG}"
 fi
 
 ROOT_DIR="$(resolve_root_dir "$ROOT_DIR")"
@@ -204,36 +204,36 @@ WORKTREE_NAME="${NORMALIZED_AGENT}-${NAME_SUFFIX}"
 
 EXISTING_WORKTREE="$(find_branch_worktree "$BRANCH_NAME" || true)"
 if [[ -n "$EXISTING_WORKTREE" && ! -d "$EXISTING_WORKTREE" ]]; then
-    git -C "$PROJECT_DIR" worktree prune >/dev/null 2>&1 || true
-    EXISTING_WORKTREE="$(find_branch_worktree "$BRANCH_NAME" || true)"
+  git -C "$PROJECT_DIR" worktree prune >/dev/null 2>&1 || true
+  EXISTING_WORKTREE="$(find_branch_worktree "$BRANCH_NAME" || true)"
 fi
 if [[ -n "$EXISTING_WORKTREE" ]]; then
-    echo "Worktree already exists:"
-    echo "  Path: $EXISTING_WORKTREE"
-    echo "  Branch: $BRANCH_NAME"
-    print_next_steps "$EXISTING_WORKTREE" "$NORMALIZED_AGENT"
-    exit 0
+  echo "Worktree already exists:"
+  echo "  Path: $EXISTING_WORKTREE"
+  echo "  Branch: $BRANCH_NAME"
+  print_next_steps "$EXISTING_WORKTREE" "$NORMALIZED_AGENT"
+  exit 0
 fi
 
 if [[ -z "$BASE_REF" ]]; then
-    BASE_REF="$(default_base_ref)"
+  BASE_REF="$(default_base_ref)"
 fi
 [[ -n "$BASE_REF" ]] || die "Could not determine a base ref"
-git -C "$PROJECT_DIR" rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null \
-    || die "Base ref not found: $BASE_REF"
+git -C "$PROJECT_DIR" rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null ||
+  die "Base ref not found: $BASE_REF"
 
 mkdir -p "$ROOT_DIR"
 ROOT_DIR="$(cd "$ROOT_DIR" && pwd -P)"
 WORKTREE_PATH="${ROOT_DIR}/${WORKTREE_NAME}"
 
 if [[ -e "$WORKTREE_PATH" ]]; then
-    die "Target path already exists: $WORKTREE_PATH"
+  die "Target path already exists: $WORKTREE_PATH"
 fi
 
 if git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
-    git -C "$PROJECT_DIR" worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+  git -C "$PROJECT_DIR" worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
 else
-    git -C "$PROJECT_DIR" worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" "$BASE_REF"
+  git -C "$PROJECT_DIR" worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" "$BASE_REF"
 fi
 
 echo "Created worktree:"

--- a/scaffold/root/scripts/remove-worktree.sh
+++ b/scaffold/root/scripts/remove-worktree.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 
 usage() {
-    cat <<EOF
+  cat <<EOF
 Usage: $0 (--branch NAME | --path DIR) [--delete-branch] [--force]
 
 Remove a non-primary git worktree from a safe working directory.
@@ -34,124 +34,124 @@ EOF
 }
 
 die() {
-    echo "Error: $*" >&2
-    exit 1
+  echo "Error: $*" >&2
+  exit 1
 }
 
 delete_local_branch() {
-    local branch_name="$1"
+  local branch_name="$1"
 
-    git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/heads/$branch_name" \
-        || die "No local branch found: $branch_name"
-    git -C "$PROJECT_DIR" branch -D "$branch_name"
+  git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/heads/$branch_name" ||
+    die "No local branch found: $branch_name"
+  git -C "$PROJECT_DIR" branch -D "$branch_name"
 }
 
 resolve_path() {
-    local raw="$1"
-    if [[ "$raw" = /* ]]; then
-        printf '%s\n' "$raw"
-    else
-        printf '%s\n' "$PROJECT_DIR/$raw"
-    fi
+  local raw="$1"
+  if [[ "$raw" = /* ]]; then
+    printf '%s\n' "$raw"
+  else
+    printf '%s\n' "$PROJECT_DIR/$raw"
+  fi
 }
 
 canonical_dir() {
-    local path="$1"
-    (
-        cd "$path" || return 1
-        pwd -P
-    )
+  local path="$1"
+  (
+    cd "$path" || return 1
+    pwd -P
+  )
 }
 
 find_shared_editable_binding() {
-    local target_path="$1"
-    local venv_dir="$PROJECT_DIR/.venv"
-    local pth_file=""
-    local bound_path=""
-    local line=""
+  local target_path="$1"
+  local venv_dir="$PROJECT_DIR/.venv"
+  local pth_file=""
+  local bound_path=""
+  local line=""
 
-    [[ -d "$venv_dir" ]] || return 1
+  [[ -d "$venv_dir" ]] || return 1
 
-    while IFS= read -r -d '' pth_file; do
-        while IFS= read -r line || [[ -n "$line" ]]; do
-            [[ -n "$line" ]] || continue
-            [[ "$line" != \#* ]] || continue
-            [[ -d "$line" ]] || continue
-            bound_path="$(canonical_dir "$line" 2>/dev/null || true)"
-            [[ -n "$bound_path" ]] || continue
-            if [[ "$bound_path" == "$target_path" || "$bound_path" == "$target_path/"* ]]; then
-                printf '%s\n' "$bound_path"
-                return 0
-            fi
-        done < "$pth_file"
-    done < <(find "$venv_dir" -type f -path '*/site-packages/*.pth' -print0 2>/dev/null)
+  while IFS= read -r -d '' pth_file; do
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      [[ -n "$line" ]] || continue
+      [[ "$line" != \#* ]] || continue
+      [[ -d "$line" ]] || continue
+      bound_path="$(canonical_dir "$line" 2>/dev/null || true)"
+      [[ -n "$bound_path" ]] || continue
+      if [[ "$bound_path" == "$target_path" || "$bound_path" == "$target_path/"* ]]; then
+        printf '%s\n' "$bound_path"
+        return 0
+      fi
+    done <"$pth_file"
+  done < <(find "$venv_dir" -type f -path '*/site-packages/*.pth' -print0 2>/dev/null)
 
-    return 1
+  return 1
 }
 
 find_branch_worktree() {
-    local branch_name="$1"
-    local current_worktree=""
-    local line=""
+  local branch_name="$1"
+  local current_worktree=""
+  local line=""
 
-    while IFS= read -r line; do
-        case "$line" in
-            worktree\ *)
-                current_worktree="${line#worktree }"
-                ;;
-            branch\ refs/heads/*)
-                if [[ "${line#branch refs/heads/}" == "$branch_name" ]]; then
-                    printf '%s\n' "$current_worktree"
-                    return 0
-                fi
-                ;;
-        esac
-    done < <(git -C "$PROJECT_DIR" worktree list --porcelain)
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *)
+        current_worktree="${line#worktree }"
+        ;;
+      branch\ refs/heads/*)
+        if [[ "${line#branch refs/heads/}" == "$branch_name" ]]; then
+          printf '%s\n' "$current_worktree"
+          return 0
+        fi
+        ;;
+    esac
+  done < <(git -C "$PROJECT_DIR" worktree list --porcelain)
 
-    return 1
+  return 1
 }
 
 find_worktree_branch() {
-    local target_path="$1"
-    local current_worktree=""
-    local current_branch=""
-    local current_worktree_real=""
-    local line=""
+  local target_path="$1"
+  local current_worktree=""
+  local current_branch=""
+  local current_worktree_real=""
+  local line=""
 
-    while IFS= read -r line; do
-        case "$line" in
-            worktree\ *)
-                current_worktree="${line#worktree }"
-                ;;
-            branch\ refs/heads/*)
-                current_branch="${line#branch refs/heads/}"
-                current_worktree_real="$(canonical_dir "$current_worktree" 2>/dev/null || true)"
-                if [[ "$current_worktree_real" == "$target_path" ]]; then
-                    printf '%s\n' "$current_branch"
-                    return 0
-                fi
-                ;;
-        esac
-    done < <(git -C "$PROJECT_DIR" worktree list --porcelain)
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *)
+        current_worktree="${line#worktree }"
+        ;;
+      branch\ refs/heads/*)
+        current_branch="${line#branch refs/heads/}"
+        current_worktree_real="$(canonical_dir "$current_worktree" 2>/dev/null || true)"
+        if [[ "$current_worktree_real" == "$target_path" ]]; then
+          printf '%s\n' "$current_branch"
+          return 0
+        fi
+        ;;
+    esac
+  done < <(git -C "$PROJECT_DIR" worktree list --porcelain)
 
-    return 1
+  return 1
 }
 
 require_git_repo() {
-    git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
-        || die "Not inside a git worktree: $PROJECT_DIR"
+  git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
+    die "Not inside a git worktree: $PROJECT_DIR"
 }
 
 ensure_safe_cwd() {
-    local target_path="$1"
-    local pwd_real
+  local target_path="$1"
+  local pwd_real
 
-    pwd_real="$(pwd -P)"
-    case "$pwd_real/" in
-        "$target_path/"*)
-            die "Refusing to remove worktree containing current working directory: $target_path. Run this command from $PROJECT_DIR or /tmp and retry."
-            ;;
-    esac
+  pwd_real="$(pwd -P)"
+  case "$pwd_real/" in
+    "$target_path/"*)
+      die "Refusing to remove worktree containing current working directory: $target_path. Run this command from $PROJECT_DIR or /tmp and retry."
+      ;;
+  esac
 }
 
 BRANCH_NAME=""
@@ -160,114 +160,114 @@ DELETE_BRANCH=false
 FORCE_REMOVE=false
 
 while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --branch)
-            [[ $# -ge 2 ]] || die "Missing value for --branch"
-            BRANCH_NAME="$2"
-            shift 2
-            ;;
-        --path)
-            [[ $# -ge 2 ]] || die "Missing value for --path"
-            TARGET_PATH="$2"
-            shift 2
-            ;;
-        --delete-branch)
-            DELETE_BRANCH=true
-            shift
-            ;;
-        --force)
-            FORCE_REMOVE=true
-            shift
-            ;;
-        -h|--help)
-            usage
-            exit 0
-            ;;
-        *)
-            die "Unknown option: $1"
-            ;;
-    esac
+  case "$1" in
+    --branch)
+      [[ $# -ge 2 ]] || die "Missing value for --branch"
+      BRANCH_NAME="$2"
+      shift 2
+      ;;
+    --path)
+      [[ $# -ge 2 ]] || die "Missing value for --path"
+      TARGET_PATH="$2"
+      shift 2
+      ;;
+    --delete-branch)
+      DELETE_BRANCH=true
+      shift
+      ;;
+    --force)
+      FORCE_REMOVE=true
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1"
+      ;;
+  esac
 done
 
 require_git_repo
 
 if [[ -z "$BRANCH_NAME" && -z "$TARGET_PATH" ]]; then
-    die "Either --branch or --path is required"
+  die "Either --branch or --path is required"
 fi
 
 if [[ -n "$BRANCH_NAME" ]]; then
-    resolved_path="$(find_branch_worktree "$BRANCH_NAME" || true)"
-    if [[ -z "$resolved_path" ]]; then
-        if [[ "$DELETE_BRANCH" == true && -z "$TARGET_PATH" ]]; then
-            echo "No worktree found for branch; deleting local branch only:"
-            echo "  Branch: $BRANCH_NAME"
-            delete_local_branch "$BRANCH_NAME"
-            exit 0
-        fi
-        die "No worktree found for branch: $BRANCH_NAME"
+  resolved_path="$(find_branch_worktree "$BRANCH_NAME" || true)"
+  if [[ -z "$resolved_path" ]]; then
+    if [[ "$DELETE_BRANCH" == true && -z "$TARGET_PATH" ]]; then
+      echo "No worktree found for branch; deleting local branch only:"
+      echo "  Branch: $BRANCH_NAME"
+      delete_local_branch "$BRANCH_NAME"
+      exit 0
     fi
-    if [[ ! -d "$resolved_path" ]]; then
-        git -C "$PROJECT_DIR" worktree prune >/dev/null 2>&1 || true
-        if [[ "$DELETE_BRANCH" == true && -z "$TARGET_PATH" ]]; then
-            echo "Pruned stale worktree record for missing directory: $resolved_path"
-            echo "Deleting remaining local branch:"
-            echo "  Branch: $BRANCH_NAME"
-            delete_local_branch "$BRANCH_NAME"
-            exit 0
-        fi
-        die "Worktree record for branch '$BRANCH_NAME' points to a missing directory. Stale metadata was pruned; pass --delete-branch without --path to delete the remaining local branch."
+    die "No worktree found for branch: $BRANCH_NAME"
+  fi
+  if [[ ! -d "$resolved_path" ]]; then
+    git -C "$PROJECT_DIR" worktree prune >/dev/null 2>&1 || true
+    if [[ "$DELETE_BRANCH" == true && -z "$TARGET_PATH" ]]; then
+      echo "Pruned stale worktree record for missing directory: $resolved_path"
+      echo "Deleting remaining local branch:"
+      echo "  Branch: $BRANCH_NAME"
+      delete_local_branch "$BRANCH_NAME"
+      exit 0
     fi
-    resolved_path="$(canonical_dir "$resolved_path")" \
-        || die "Worktree path does not exist: $resolved_path"
-    if [[ -n "$TARGET_PATH" ]]; then
-        raw_target_path="$(resolve_path "$TARGET_PATH")"
-        [[ -d "$raw_target_path" ]] || die "Worktree path does not exist: $raw_target_path"
-        TARGET_PATH="$(canonical_dir "$raw_target_path")" \
-            || die "Worktree path does not exist: $raw_target_path"
-        [[ "$TARGET_PATH" == "$resolved_path" ]] \
-            || die "--branch and --path refer to different worktrees"
-    else
-        TARGET_PATH="$resolved_path"
-    fi
-else
+    die "Worktree record for branch '$BRANCH_NAME' points to a missing directory. Stale metadata was pruned; pass --delete-branch without --path to delete the remaining local branch."
+  fi
+  resolved_path="$(canonical_dir "$resolved_path")" ||
+    die "Worktree path does not exist: $resolved_path"
+  if [[ -n "$TARGET_PATH" ]]; then
     raw_target_path="$(resolve_path "$TARGET_PATH")"
     [[ -d "$raw_target_path" ]] || die "Worktree path does not exist: $raw_target_path"
-    TARGET_PATH="$(canonical_dir "$raw_target_path")" \
-        || die "Worktree path does not exist: $raw_target_path"
+    TARGET_PATH="$(canonical_dir "$raw_target_path")" ||
+      die "Worktree path does not exist: $raw_target_path"
+    [[ "$TARGET_PATH" == "$resolved_path" ]] ||
+      die "--branch and --path refer to different worktrees"
+  else
+    TARGET_PATH="$resolved_path"
+  fi
+else
+  raw_target_path="$(resolve_path "$TARGET_PATH")"
+  [[ -d "$raw_target_path" ]] || die "Worktree path does not exist: $raw_target_path"
+  TARGET_PATH="$(canonical_dir "$raw_target_path")" ||
+    die "Worktree path does not exist: $raw_target_path"
 fi
 
 [[ -d "$TARGET_PATH" ]] || die "Worktree path does not exist: $TARGET_PATH"
 
 if [[ -z "$BRANCH_NAME" ]]; then
-    BRANCH_NAME="$(find_worktree_branch "$TARGET_PATH" || true)"
+  BRANCH_NAME="$(find_worktree_branch "$TARGET_PATH" || true)"
 fi
 
 if [[ "$DELETE_BRANCH" == true ]]; then
-    [[ -n "$BRANCH_NAME" ]] || die "--delete-branch requires a branch-backed worktree"
+  [[ -n "$BRANCH_NAME" ]] || die "--delete-branch requires a branch-backed worktree"
 fi
 
-[[ "$TARGET_PATH" != "$PROJECT_DIR" ]] \
-    || die "Refusing to remove primary checkout: $PROJECT_DIR"
+[[ "$TARGET_PATH" != "$PROJECT_DIR" ]] ||
+  die "Refusing to remove primary checkout: $PROJECT_DIR"
 
 ensure_safe_cwd "$TARGET_PATH"
 
 bound_editable_path="$(find_shared_editable_binding "$TARGET_PATH" || true)"
 if [[ -n "$bound_editable_path" ]]; then
-    die "Refusing to remove worktree while the shared .venv editable install points inside it: $bound_editable_path. Reinstall the editable package from the main checkout first, then retry."
+  die "Refusing to remove worktree while the shared .venv editable install points inside it: $bound_editable_path. Reinstall the editable package from the main checkout first, then retry."
 fi
 
 if [[ "$FORCE_REMOVE" == true ]]; then
-    git -C "$PROJECT_DIR" worktree remove "$TARGET_PATH" --force
+  git -C "$PROJECT_DIR" worktree remove "$TARGET_PATH" --force
 else
-    git -C "$PROJECT_DIR" worktree remove "$TARGET_PATH"
+  git -C "$PROJECT_DIR" worktree remove "$TARGET_PATH"
 fi
 
 echo "Removed worktree:"
 echo "  Path: $TARGET_PATH"
 if [[ -n "$BRANCH_NAME" ]]; then
-    echo "  Branch: $BRANCH_NAME"
+  echo "  Branch: $BRANCH_NAME"
 fi
 
 if [[ "$DELETE_BRANCH" == true ]]; then
-    delete_local_branch "$BRANCH_NAME"
+  delete_local_branch "$BRANCH_NAME"
 fi

--- a/scripts/check-style.sh
+++ b/scripts/check-style.sh
@@ -59,7 +59,10 @@ if [[ "${#missing_tools[@]}" -gt 0 ]]; then
 
 Install them locally before running this command:
   macOS:   brew install shellcheck shfmt
-  Ubuntu: install ShellCheck and shfmt from their pinned release binaries.
+  Ubuntu: sudo apt-get update && sudo apt-get install -y shellcheck
+          curl -fsSL -o shfmt https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 shfmt "$HOME/.local/bin/shfmt"
 
 CI pins the exact tool versions in .github/workflows/style-check.yml.
 EOF

--- a/scripts/check-style.sh
+++ b/scripts/check-style.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SHELLCHECK_BIN="${SHELLCHECK_BIN:-shellcheck}"
+SHFMT_BIN="${SHFMT_BIN:-shfmt}"
+SHELLCHECK_SEVERITY="warning"
+SHFMT_FLAGS=(-i 2 -ci)
+
+usage() {
+  cat <<EOF
+Usage: $0 [--fix|--write]
+
+Run shell syntax, static-analysis, and formatting checks.
+
+Options:
+  --fix, --write  Rewrite shell formatting with shfmt instead of printing a diff.
+  -h, --help      Show this help.
+EOF
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+fix_mode="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fix | --write)
+      fix_mode="true"
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1"
+      ;;
+  esac
+done
+
+cd "$repo_root"
+
+missing_tools=()
+for tool in "$SHELLCHECK_BIN" "$SHFMT_BIN"; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    missing_tools+=("$tool")
+  fi
+done
+
+if [[ "${#missing_tools[@]}" -gt 0 ]]; then
+  echo "Missing required style-check tool(s): ${missing_tools[*]}" >&2
+  cat >&2 <<'EOF'
+
+Install them locally before running this command:
+  macOS:   brew install shellcheck shfmt
+  Ubuntu: install ShellCheck and shfmt from their pinned release binaries.
+
+CI pins the exact tool versions in .github/workflows/style-check.yml.
+EOF
+  exit 127
+fi
+
+targets=()
+
+add_target() {
+  local file_path="$1"
+  local existing
+
+  if [[ "${#targets[@]}" -gt 0 ]]; then
+    for existing in "${targets[@]}"; do
+      if [[ "$existing" == "$file_path" ]]; then
+        return 0
+      fi
+    done
+  fi
+
+  targets+=("$file_path")
+}
+
+is_direct_child_sh_file() {
+  local file_path="$1"
+  local directory="$2"
+  local relative_path=""
+
+  case "$file_path" in
+    "$directory"/*.sh)
+      relative_path="${file_path#${directory}/}"
+      [[ "$relative_path" != */* ]]
+      return
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+has_shell_shebang() {
+  local file_path="$1"
+  local first_line=""
+
+  IFS= read -r first_line <"$repo_root/$file_path" || return 1
+  [[ "$first_line" == '#!'*bash* || "$first_line" == '#!'*'/sh'* || "$first_line" == '#!'*' sh'* ]]
+}
+
+# Keep target roots explicit. If future test fixtures need intentionally broken
+# shell, add a narrow opt-out instead of broadening discovery.
+while IFS= read -r file_path; do
+  [[ -n "$file_path" ]] || continue
+
+  if is_direct_child_sh_file "$file_path" "scripts" ||
+    is_direct_child_sh_file "$file_path" "scripts/lib" ||
+    is_direct_child_sh_file "$file_path" "scaffold/root/scripts" ||
+    is_direct_child_sh_file "$file_path" "scaffold/agent-vault/_assets/hooks/lib"; then
+    add_target "$file_path"
+    continue
+  fi
+
+  case "$file_path" in
+    scaffold/agent-vault/_assets/hooks/*)
+      if [[ -f "$repo_root/$file_path" ]] && has_shell_shebang "$file_path"; then
+        add_target "$file_path"
+      fi
+      ;;
+  esac
+done < <(git ls-files)
+
+if [[ -f "scripts/check-style.sh" ]]; then
+  add_target "scripts/check-style.sh"
+fi
+
+if [[ "${#targets[@]}" -eq 0 ]]; then
+  echo "No shell style-check targets found."
+  exit 0
+fi
+
+echo "Checking ${#targets[@]} shell file(s)."
+echo "Running bash syntax checks..."
+for file_path in "${targets[@]}"; do
+  bash -n "$file_path"
+done
+
+echo "Running ShellCheck with --severity=$SHELLCHECK_SEVERITY..."
+"$SHELLCHECK_BIN" --severity="$SHELLCHECK_SEVERITY" -x "${targets[@]}"
+
+if [[ "$fix_mode" == "true" ]]; then
+  echo "Formatting shell files with shfmt ${SHFMT_FLAGS[*]} -w..."
+  "$SHFMT_BIN" "${SHFMT_FLAGS[@]}" -w "${targets[@]}"
+else
+  echo "Checking shell formatting with shfmt ${SHFMT_FLAGS[*]} -d..."
+  "$SHFMT_BIN" "${SHFMT_FLAGS[@]}" -d "${targets[@]}"
+fi
+
+echo "Shell style checks passed."

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -14,15 +14,15 @@ usage() {
 expand_path() {
   local p="$1"
   case "$p" in
-    "~")
+    \~)
       printf '%s\n' "$HOME"
       ;;
-    "~/"*)
-      printf '%s/%s\n' "$HOME" "${p#~/}"
+    \~/*)
+      printf '%s/%s\n' "$HOME" "${p#\~/}"
       ;;
-    "/~/"*)
+    /\~/*)
       # Common typo: /~/path should usually be ~/path.
-      printf '%s/%s\n' "$HOME" "${p#/~/}"
+      printf '%s/%s\n' "$HOME" "${p#/\~/}"
       ;;
     *)
       printf '%s\n' "$p"
@@ -35,7 +35,7 @@ validate_write_path() {
   local current_path="$destination_path"
 
   case "$destination_path" in
-    "$canonical_repo_path"|"$canonical_repo_path"/*) ;;
+    "$canonical_repo_path" | "$canonical_repo_path"/*) ;;
     *)
       return 2
       ;;
@@ -124,7 +124,7 @@ append_migrated_root_content() {
     printf '```md\n'
     cat "$source_path"
     printf '\n```\n'
-  } >> "$destination_path"
+  } >>"$destination_path"
 }
 
 # Contract: each block starts with a human-readable comment line followed by
@@ -189,7 +189,7 @@ collect_missing_managed_gitignore_lines() {
 
       missing_block_lines+=("$line")
       missing_pattern_count=$((missing_pattern_count + 1))
-    done <<< "$block"
+    done <<<"$block"
 
     # Skip orphaned comments when the ignore patterns already exist.
     if [[ "$missing_pattern_count" -eq 0 ]]; then
@@ -221,12 +221,12 @@ ensure_managed_gitignore_entries() {
   fi
 
   if [[ ! -e "$gitignore_path" ]]; then
-    : > "$gitignore_path"
+    : >"$gitignore_path"
   fi
 
   while IFS= read -r line; do
     [[ -n "$line" ]] || continue
-    printf '%s\n' "$line" >> "$gitignore_path"
+    printf '%s\n' "$line" >>"$gitignore_path"
     added_count=$((added_count + 1))
   done < <(collect_missing_managed_gitignore_lines "$gitignore_path")
 
@@ -246,7 +246,7 @@ for arg in "$@"; do
     --migrate-existing-root-md)
       migrate_existing_root_md="true"
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
@@ -323,8 +323,7 @@ for required in \
   "$root_scaffold_dir/docs/design.md" \
   "$root_scaffold_dir/docs/runbooks/parallel-agent-worktrees.md" \
   "$root_scaffold_dir/scripts/new-worktree.sh" \
-  "$root_scaffold_dir/scripts/remove-worktree.sh"
-do
+  "$root_scaffold_dir/scripts/remove-worktree.sh"; do
   if [[ ! -f "$required" ]]; then
     echo "Error: missing root scaffold file: $required"
     exit 1
@@ -342,8 +341,7 @@ for required in \
   "$scaffold_dir/design-log/README.md" \
   "$scaffold_dir/context/handoffs/README.md" \
   "$scaffold_dir/decisions/README.md" \
-  "$scaffold_dir/daily/README.md"
-do
+  "$scaffold_dir/daily/README.md"; do
   if [[ ! -f "$required" ]]; then
     echo "Error: missing scaffold file: $required"
     exit 1

--- a/scripts/test-coding-standards-sync.sh
+++ b/scripts/test-coding-standards-sync.sh
@@ -82,7 +82,7 @@ find_coding_standards_backup() {
 project_owned_repo="$tmp_root/project-owned-by-default"
 init_repo "$project_owned_repo"
 "$repo_root/scripts/new-project.sh" "coding-standards-test" "$project_owned_repo" >/dev/null
-cat <<'EOF' > "$project_owned_repo/agent-vault/coding-standards.md"
+cat <<'EOF' >"$project_owned_repo/agent-vault/coding-standards.md"
 # Coding Standards
 
 ## Custom Rules

--- a/scripts/test-decision-template-sync.sh
+++ b/scripts/test-decision-template-sync.sh
@@ -86,7 +86,7 @@ repo_path="$tmp_root/policy-template-sync"
 init_repo "$repo_path"
 "$repo_root/scripts/new-project.sh" "template-sync-test" "$repo_path" >/dev/null
 
-cat <<'EOF' > "$repo_path/agent-vault/Templates/Decision Record.md"
+cat <<'EOF' >"$repo_path/agent-vault/Templates/Decision Record.md"
 ---
 type: decision-record
 id:
@@ -120,7 +120,7 @@ scope:
 - [ ] Update `agent-vault/decision-log.md`
 EOF
 
-cat <<'EOF' > "$repo_path/agent-vault/Templates/Daily Note.md"
+cat <<'EOF' >"$repo_path/agent-vault/Templates/Daily Note.md"
 # Custom Daily Template
 EOF
 

--- a/scripts/test-gitignore-management.sh
+++ b/scripts/test-gitignore-management.sh
@@ -97,7 +97,7 @@ init_repo() {
 write_legacy_gitignore() {
   local repo_path="$1"
 
-  cat <<'EOF' > "$repo_path/.gitignore"
+  cat <<'EOF' >"$repo_path/.gitignore"
 .obsidian/workspace.json
 .obsidian/app.json
 .obsidian/appearance.json
@@ -111,7 +111,7 @@ EOF
 write_partial_obsidian_gitignore() {
   local repo_path="$1"
 
-  cat <<'EOF' > "$repo_path/.gitignore"
+  cat <<'EOF' >"$repo_path/.gitignore"
 .obsidian/workspace.json
 .obsidian/app.json
 EOF
@@ -120,7 +120,7 @@ EOF
 write_managed_gitignore() {
   local repo_path="$1"
 
-  cat <<'EOF' > "$repo_path/.gitignore"
+  cat <<'EOF' >"$repo_path/.gitignore"
 # Obsidian -- machine-specific & volatile files (ignore these)
 .obsidian/workspace.json
 .obsidian/app.json

--- a/scripts/test-main-push-gate.sh
+++ b/scripts/test-main-push-gate.sh
@@ -142,8 +142,8 @@ printf 'plain repo update\n' >"$no_vault_repo/README.md"
 git -C "$no_vault_repo" commit -am "Change plain repo" >/dev/null
 no_vault_local_sha="$(git -C "$no_vault_repo" rev-parse HEAD)"
 (cd "$no_vault_repo" && printf '%s %s %s %s\n' \
-  "refs/heads/main" "$no_vault_local_sha" "refs/heads/main" "$no_vault_remote_sha" \
-  | "$repo_root/scaffold/agent-vault/_assets/hooks/pre-push")
+  "refs/heads/main" "$no_vault_local_sha" "refs/heads/main" "$no_vault_remote_sha" |
+  "$repo_root/scaffold/agent-vault/_assets/hooks/pre-push")
 
 missing_vault_repo="$tmp_root/enabled-missing-agent-vault-blocked"
 seed_project "$missing_vault_repo"
@@ -153,8 +153,8 @@ git -C "$missing_vault_repo" rm -r agent-vault >/dev/null
 (cd "$missing_vault_repo" && git -c core.hooksPath=/dev/null commit -m "Remove agent-vault directory" >/dev/null)
 missing_vault_local_sha="$(git -C "$missing_vault_repo" rev-parse HEAD)"
 if missing_vault_output="$(cd "$missing_vault_repo" && printf '%s %s %s %s\n' \
-  "refs/heads/main" "$missing_vault_local_sha" "refs/heads/main" "$missing_vault_remote_sha" \
-  | "$repo_root/scaffold/agent-vault/_assets/hooks/pre-push" 2>&1)"; then
+  "refs/heads/main" "$missing_vault_local_sha" "refs/heads/main" "$missing_vault_remote_sha" |
+  "$repo_root/scaffold/agent-vault/_assets/hooks/pre-push" 2>&1)"; then
   echo "Expected pre-push hook to fail when agent-vault is missing but the main push gate is enabled." >&2
   exit 1
 fi
@@ -178,8 +178,8 @@ global_config_remote_sha="$(git -C "$global_config_repo" rev-parse HEAD)"
 commit_source_change "$global_config_repo"
 global_config_local_sha="$(git -C "$global_config_repo" rev-parse HEAD)"
 (cd "$global_config_repo" && printf '%s %s %s %s\n' \
-  "refs/heads/main" "$global_config_local_sha" "refs/heads/main" "$global_config_remote_sha" \
-  | GIT_CONFIG_GLOBAL="$global_config_file" agent-vault/_assets/hooks/pre-push)
+  "refs/heads/main" "$global_config_local_sha" "refs/heads/main" "$global_config_remote_sha" |
+  GIT_CONFIG_GLOBAL="$global_config_file" agent-vault/_assets/hooks/pre-push)
 
 metadata_repo="$tmp_root/metadata-only-allowed"
 seed_project "$metadata_repo"
@@ -257,8 +257,7 @@ for blocked_path in \
   agent-vault/shared-rules.md \
   agent-vault/review-policy.md \
   "agent-vault/Templates/Plan.md" \
-  agent-vault/_assets/hooks/pre-commit
-do
+  agent-vault/_assets/hooks/pre-commit; do
   blocked_repo="$tmp_root/blocked-${blocked_path//\//-}"
   seed_project "$blocked_repo"
   enable_gate "$blocked_repo"

--- a/scripts/test-new-worktree.sh
+++ b/scripts/test-new-worktree.sh
@@ -103,7 +103,7 @@ setup_repo() {
   mkdir -p "$seed/scripts"
   cp "$helper_source" "$seed/scripts/new-worktree.sh"
   chmod +x "$seed/scripts/new-worktree.sh"
-  echo "seed" > "$seed/README.md"
+  echo "seed" >"$seed/README.md"
   git -C "$seed" add README.md scripts/new-worktree.sh
   git -C "$seed" commit -m "seed" >/dev/null
   git -C "$seed" remote add origin "$origin"

--- a/scripts/test-path-expansion.sh
+++ b/scripts/test-path-expansion.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/agent-vault-path-expansion-test.XXXXXX")"
+
+cleanup() {
+  rm -rf "$tmp_root"
+}
+
+trap cleanup EXIT
+
+assert_output_contains() {
+  local output="$1"
+  local expected_text="$2"
+
+  if [[ "$output" != *"$expected_text"* ]]; then
+    echo "Expected text not found in command output: $expected_text" >&2
+    echo "Actual output:" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+}
+
+assert_file_exists() {
+  local file_path="$1"
+
+  if [[ ! -f "$file_path" ]]; then
+    echo "Expected file not found: $file_path" >&2
+    exit 1
+  fi
+}
+
+assert_path_not_exists() {
+  local path="$1"
+
+  if [[ -e "$path" ]]; then
+    echo "Expected path to be absent: $path" >&2
+    exit 1
+  fi
+}
+
+init_repo() {
+  local repo_path="$1"
+
+  mkdir -p "$repo_path"
+  git -C "$repo_path" init >/dev/null
+}
+
+fake_home="$tmp_root/home"
+mkdir -p "$fake_home/workspaces"
+
+new_project_tilde_repo="$fake_home/workspaces/new-project-tilde"
+init_repo "$new_project_tilde_repo"
+# shellcheck disable=SC2088 # Intentionally pass literal ~/ for expand_path coverage.
+HOME="$fake_home" "$repo_root/scripts/new-project.sh" "path-expansion-test" "~/workspaces/new-project-tilde" >/dev/null
+assert_file_exists "$new_project_tilde_repo/agent-vault/README.md"
+assert_path_not_exists "$fake_home/~/workspaces/new-project-tilde"
+
+new_project_home_repo="$tmp_root/home-repo"
+init_repo "$new_project_home_repo"
+HOME="$new_project_home_repo" "$repo_root/scripts/new-project.sh" "path-expansion-test" "~" >/dev/null
+assert_file_exists "$new_project_home_repo/agent-vault/README.md"
+
+new_project_typo_repo="$fake_home/workspaces/new-project-typo"
+init_repo "$new_project_typo_repo"
+typo_output="$(HOME="$fake_home" "$repo_root/scripts/new-project.sh" "path-expansion-test" "/~/workspaces/new-project-typo" 2>&1)"
+assert_output_contains "$typo_output" "Warning: interpreted '/~/workspaces/new-project-typo' as '$new_project_typo_repo'."
+assert_file_exists "$new_project_typo_repo/agent-vault/README.md"
+
+update_project_absolute_repo="$fake_home/workspaces/update-absolute"
+init_repo "$update_project_absolute_repo"
+"$repo_root/scripts/new-project.sh" "path-expansion-test" "$update_project_absolute_repo" >/dev/null
+"$repo_root/scripts/update-project.sh" "$update_project_absolute_repo" --dry-run >/dev/null
+assert_file_exists "$update_project_absolute_repo/agent-vault/README.md"
+
+update_project_tilde_repo="$fake_home/workspaces/update-tilde"
+init_repo "$update_project_tilde_repo"
+"$repo_root/scripts/new-project.sh" "path-expansion-test" "$update_project_tilde_repo" >/dev/null
+# shellcheck disable=SC2088 # Intentionally pass literal ~/ for expand_path coverage.
+HOME="$fake_home" "$repo_root/scripts/update-project.sh" "~/workspaces/update-tilde" --dry-run >/dev/null
+assert_file_exists "$update_project_tilde_repo/agent-vault/README.md"
+assert_path_not_exists "$fake_home/~/workspaces/update-tilde"
+
+update_project_home_repo="$tmp_root/update-home-repo"
+init_repo "$update_project_home_repo"
+"$repo_root/scripts/new-project.sh" "path-expansion-test" "$update_project_home_repo" >/dev/null
+HOME="$update_project_home_repo" "$repo_root/scripts/update-project.sh" "~" --dry-run >/dev/null
+assert_file_exists "$update_project_home_repo/agent-vault/README.md"
+
+update_project_typo_repo="$fake_home/workspaces/update-typo"
+init_repo "$update_project_typo_repo"
+"$repo_root/scripts/new-project.sh" "path-expansion-test" "$update_project_typo_repo" >/dev/null
+update_typo_output="$(HOME="$fake_home" "$repo_root/scripts/update-project.sh" "/~/workspaces/update-typo" --dry-run 2>&1)"
+assert_output_contains "$update_typo_output" "Warning: interpreted '/~/workspaces/update-typo' as '$update_project_typo_repo'."
+assert_file_exists "$update_project_typo_repo/agent-vault/README.md"
+
+echo "path expansion regression checks passed."

--- a/scripts/test-remove-worktree.sh
+++ b/scripts/test-remove-worktree.sh
@@ -87,7 +87,7 @@ setup_repo() {
   mkdir -p "$seed/scripts"
   cp "$helper_source" "$seed/scripts/remove-worktree.sh"
   chmod +x "$seed/scripts/remove-worktree.sh"
-  echo "seed" > "$seed/README.md"
+  echo "seed" >"$seed/README.md"
   git -C "$seed" add README.md scripts/remove-worktree.sh
   git -C "$seed" commit -m "seed" >/dev/null
   git -C "$seed" remote add origin "$origin"
@@ -122,7 +122,7 @@ create_detached_worktree() {
 working="$(setup_repo repo1)"
 worktree_path="$(create_worktree "$working" "codex/123-feature-slice" "codex-123-feature-slice")"
 mkdir -p "$working/.venv/lib/python3.10/site-packages" "$worktree_path/src"
-printf '%s\n' "$worktree_path/src" > "$working/.venv/lib/python3.10/site-packages/editable_project.pth"
+printf '%s\n' "$worktree_path/src" >"$working/.venv/lib/python3.10/site-packages/editable_project.pth"
 rc=0
 output="$(cd "$working" && bash scripts/remove-worktree.sh --branch codex/123-feature-slice 2>&1)" || rc=$?
 assert_exit_code 1 "$rc" "remove-bound-worktree exits 1"
@@ -186,7 +186,7 @@ working="$(setup_repo repo7)"
 worktree_path="$(create_worktree "$working" "codex/126-unrelated-venv" "codex-126-unrelated-venv")"
 unrelated_path="$tmp_root/unrelated-editable/src"
 mkdir -p "$working/.venv/lib/python3.10/site-packages" "$unrelated_path"
-printf '%s\n' "$unrelated_path" > "$working/.venv/lib/python3.10/site-packages/editable_project.pth"
+printf '%s\n' "$unrelated_path" >"$working/.venv/lib/python3.10/site-packages/editable_project.pth"
 rc=0
 output="$(cd "$working" && bash scripts/remove-worktree.sh --branch codex/126-unrelated-venv 2>&1)" || rc=$?
 assert_exit_code 0 "$rc" "remove-unrelated-venv exits 0"
@@ -195,7 +195,7 @@ assert_path_missing "$worktree_path" "remove-unrelated-venv deleted target path"
 # --- Test 8: Force removal succeeds for a dirty disposable worktree ---
 working="$(setup_repo repo8)"
 worktree_path="$(create_worktree "$working" "codex/127-force-dirty" "codex-127-force-dirty")"
-echo "dirty" > "$worktree_path/untracked.txt"
+echo "dirty" >"$worktree_path/untracked.txt"
 rc=0
 output="$(cd "$working" && bash scripts/remove-worktree.sh --branch codex/127-force-dirty --force 2>&1)" || rc=$?
 assert_exit_code 0 "$rc" "remove-force-dirty exits 0"

--- a/scripts/test-session-metadata-hook.sh
+++ b/scripts/test-session-metadata-hook.sh
@@ -127,7 +127,7 @@ if [[ "$(git -C "$hook_repo" config --local --get core.hooksPath)" != "agent-vau
 fi
 
 mkdir -p "$hook_repo/src"
-printf 'print(\"hello\")\n' > "$hook_repo/src/app.py"
+printf 'print(\"hello\")\n' >"$hook_repo/src/app.py"
 git -C "$hook_repo" add src/app.py
 
 failure_output="$(run_hook_expect_failure "$hook_repo")"
@@ -137,13 +137,13 @@ assert_output_contains "$failure_output" "stage one note under agent-vault/daily
 assert_output_contains "$failure_output" "stage one note under agent-vault/design-log/"
 (cd "$hook_repo" && AGENT_VAULT_SKIP_METADATA_GATE=1 agent-vault/_assets/hooks/pre-commit)
 
-printf '\nHook coverage update.\n' >> "$hook_repo/agent-vault/context-log.md"
-cat <<EOF > "$hook_repo/agent-vault/daily/$today.md"
+printf '\nHook coverage update.\n' >>"$hook_repo/agent-vault/context-log.md"
+cat <<EOF >"$hook_repo/agent-vault/daily/$today.md"
 # Daily Note
 
 - Verified hook coverage.
 EOF
-cat <<EOF > "$hook_repo/agent-vault/design-log/$today-0100-hook-coverage.md"
+cat <<EOF >"$hook_repo/agent-vault/design-log/$today-0100-hook-coverage.md"
 # Design Log
 
 - Verified metadata gate behavior.
@@ -158,7 +158,7 @@ run_hook_expect_success "$hook_repo"
 metadata_only_repo="$tmp_root/metadata-only"
 init_repo "$metadata_only_repo"
 "$repo_root/scripts/new-project.sh" "hook-test" "$metadata_only_repo" >/dev/null
-printf '\nMetadata-only change.\n' >> "$metadata_only_repo/agent-vault/context-log.md"
+printf '\nMetadata-only change.\n' >>"$metadata_only_repo/agent-vault/context-log.md"
 git -C "$metadata_only_repo" add agent-vault/context-log.md
 run_hook_expect_success "$metadata_only_repo"
 
@@ -223,13 +223,13 @@ assert_output_contains "$(cat "$legacy_known_repo/agent-vault/context-log.md")" 
 assert_output_contains "$(cat "$legacy_known_repo/agent-vault/context-log.md")" "## Historical Snapshot"
 assert_output_contains "$(cat "$legacy_known_repo/agent-vault/context-log.md")" "## Historical Indexed Entries"
 mkdir -p "$legacy_known_repo/src"
-printf 'print(\"legacy migration\")\n' > "$legacy_known_repo/src/app.py"
-cat <<EOF > "$legacy_known_repo/agent-vault/daily/$today.md"
+printf 'print(\"legacy migration\")\n' >"$legacy_known_repo/src/app.py"
+cat <<EOF >"$legacy_known_repo/agent-vault/daily/$today.md"
 # Daily Note
 
 - Validate migrated context-log compatibility.
 EOF
-cat <<EOF > "$legacy_known_repo/agent-vault/design-log/$today-0450-context-log-migration.md"
+cat <<EOF >"$legacy_known_repo/agent-vault/design-log/$today-0450-context-log-migration.md"
 # Design Log
 
 - Validate migrated context-log compatibility.
@@ -244,7 +244,7 @@ run_hook_expect_success "$legacy_known_repo"
 unknown_layout_repo="$tmp_root/unknown-context-log-layout"
 init_repo "$unknown_layout_repo"
 "$repo_root/scripts/new-project.sh" "hook-test" "$unknown_layout_repo" >/dev/null
-cat <<EOF > "$unknown_layout_repo/agent-vault/context-log.md"
+cat <<EOF >"$unknown_layout_repo/agent-vault/context-log.md"
 ---
 type: context-log
 project: hook-test
@@ -296,14 +296,14 @@ init_repo "$deletion_repo"
 git -C "$deletion_repo" add .
 (cd "$deletion_repo" && AGENT_VAULT_SKIP_METADATA_GATE=1 git commit -m "Bootstrap hook test fixture" >/dev/null)
 mkdir -p "$deletion_repo/src"
-printf 'print("old")\n' > "$deletion_repo/src/app.py"
-printf '\nDeletion fixture context.\n' >> "$deletion_repo/agent-vault/context-log.md"
-cat <<EOF > "$deletion_repo/agent-vault/daily/$today.md"
+printf 'print("old")\n' >"$deletion_repo/src/app.py"
+printf '\nDeletion fixture context.\n' >>"$deletion_repo/agent-vault/context-log.md"
+cat <<EOF >"$deletion_repo/agent-vault/daily/$today.md"
 # Daily Note
 
 - Seed metadata for deletion coverage.
 EOF
-cat <<EOF > "$deletion_repo/agent-vault/design-log/$today-0200-delete-coverage.md"
+cat <<EOF >"$deletion_repo/agent-vault/design-log/$today-0200-delete-coverage.md"
 # Design Log
 
 - Seed metadata for deletion coverage.
@@ -314,7 +314,7 @@ git -C "$deletion_repo" add \
   "agent-vault/daily/$today.md" \
   "agent-vault/design-log/$today-0200-delete-coverage.md"
 (cd "$deletion_repo" && AGENT_VAULT_SKIP_METADATA_GATE=1 git commit -m "Seed deletion coverage metadata" >/dev/null)
-printf 'print("new")\n' > "$deletion_repo/src/app.py"
+printf 'print("new")\n' >"$deletion_repo/src/app.py"
 git -C "$deletion_repo" add src/app.py
 git -C "$deletion_repo" rm -f \
   agent-vault/context-log.md \
@@ -353,7 +353,7 @@ ordering_repo="$tmp_root/context-log-ordering"
 init_repo "$ordering_repo"
 "$repo_root/scripts/new-project.sh" "hook-test" "$ordering_repo" >/dev/null
 replace_first_context_log_timestamp "$ordering_repo/agent-vault/context-log.md" "$today 09:00"
-cat <<EOF >> "$ordering_repo/agent-vault/context-log.md"
+cat <<EOF >>"$ordering_repo/agent-vault/context-log.md"
 
 ### $today 10:00 local - test-agent - appended newer entry below older one
 #### Goal
@@ -374,18 +374,18 @@ Exercise ordering validation.
 #### References
 - agent-vault/context-log.md
 EOF
-cat <<EOF > "$ordering_repo/agent-vault/daily/$today.md"
+cat <<EOF >"$ordering_repo/agent-vault/daily/$today.md"
 # Daily Note
 
 - Seed ordering validation fixture.
 EOF
-cat <<EOF > "$ordering_repo/agent-vault/design-log/$today-0300-context-log-ordering.md"
+cat <<EOF >"$ordering_repo/agent-vault/design-log/$today-0300-context-log-ordering.md"
 # Design Log
 
 - Seed ordering validation fixture.
 EOF
 mkdir -p "$ordering_repo/src"
-printf 'print("ordering")\n' > "$ordering_repo/src/app.py"
+printf 'print("ordering")\n' >"$ordering_repo/src/app.py"
 git -C "$ordering_repo" add \
   src/app.py \
   agent-vault/context-log.md \
@@ -400,18 +400,18 @@ init_repo "$freshness_repo"
 "$repo_root/scripts/new-project.sh" "hook-test" "$freshness_repo" >/dev/null
 replace_first_match "$freshness_repo/agent-vault/context-log.md" "last_updated: $today" "last_updated: 2000-01-01"
 replace_first_match "$freshness_repo/agent-vault/context-log.md" "- Last updated: $today" "- Last updated: 2000-01-01"
-cat <<EOF > "$freshness_repo/agent-vault/daily/$today.md"
+cat <<EOF >"$freshness_repo/agent-vault/daily/$today.md"
 # Daily Note
 
 - Seed freshness validation fixture.
 EOF
-cat <<EOF > "$freshness_repo/agent-vault/design-log/$today-0400-context-log-freshness.md"
+cat <<EOF >"$freshness_repo/agent-vault/design-log/$today-0400-context-log-freshness.md"
 # Design Log
 
 - Seed freshness validation fixture.
 EOF
 mkdir -p "$freshness_repo/src"
-printf 'print("freshness")\n' > "$freshness_repo/src/app.py"
+printf 'print("freshness")\n' >"$freshness_repo/src/app.py"
 git -C "$freshness_repo" add \
   src/app.py \
   agent-vault/context-log.md \
@@ -471,6 +471,7 @@ if [[ "$dryrun_rc" -ne 0 ]]; then
   echo "Expected configure_tracked_hooks_path to return zero on dry-run activation." >&2
   exit 1
 fi
+assert_output_contains "$dryrun_output" "Dry run: would enable tracked metadata hook via core.hooksPath=agent-vault/_assets/hooks"
 if git -C "$dryrun_rc_repo" config --local --get core.hooksPath >/dev/null 2>&1; then
   echo "Expected core.hooksPath to remain unset after dry-run activation." >&2
   exit 1

--- a/scripts/test-worktree-helper-sync.sh
+++ b/scripts/test-worktree-helper-sync.sh
@@ -143,7 +143,7 @@ assert_file_contains "$target/scripts/remove-worktree.sh" "Use only after verify
 # --- Test 3: update-project skips unmanaged helper scripts by default ---
 target="$(setup_empty_repo unmanaged-skip-target)"
 run_new_project "$target" >/dev/null
-printf '%s\n' '#!/usr/bin/env bash' 'echo custom helper' > "$target/scripts/new-worktree.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'echo custom helper' >"$target/scripts/new-worktree.sh"
 chmod +x "$target/scripts/new-worktree.sh"
 rc=0
 output="$(run_update_project "$target" 2>&1)" || rc=$?
@@ -154,7 +154,7 @@ assert_file_contains "$target/scripts/new-worktree.sh" "echo custom helper" "upd
 # --- Test 4: --migrate-root-scripts backs up and replaces unmanaged helpers ---
 target="$(setup_empty_repo unmanaged-migrate-target)"
 run_new_project "$target" >/dev/null
-printf '%s\n' '#!/usr/bin/env bash' 'echo custom helper' > "$target/scripts/new-worktree.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'echo custom helper' >"$target/scripts/new-worktree.sh"
 chmod +x "$target/scripts/new-worktree.sh"
 rc=0
 output="$(run_update_project "$target" --migrate-root-scripts 2>&1)" || rc=$?
@@ -178,12 +178,12 @@ run_new_project "$target" >/dev/null
   printf '%s\n' '#!/usr/bin/env bash'
   printf '%s\n' '# agent-vault-managed: helper-script; file=new-worktree.sh'
   printf '%s\n' 'echo stale managed helper'
-} > "$target/scripts/new-worktree.sh"
+} >"$target/scripts/new-worktree.sh"
 {
   printf '%s\n' '#!/usr/bin/env bash'
   printf '%s\n' '# agent-vault-managed: helper-script; file=remove-worktree.sh'
   printf '%s\n' 'echo stale managed remove helper'
-} > "$target/scripts/remove-worktree.sh"
+} >"$target/scripts/remove-worktree.sh"
 chmod -x "$target/scripts/new-worktree.sh"
 chmod -x "$target/scripts/remove-worktree.sh"
 rc=0
@@ -200,7 +200,7 @@ assert_executable "$target/scripts/remove-worktree.sh" "update-project fixes man
 # --- Test 6: runbook is seed-only after creation ---
 target="$(setup_empty_repo runbook-seed-target)"
 run_new_project "$target" >/dev/null
-printf '%s\n' '# Local Worktree Runbook' > "$target/docs/runbooks/parallel-agent-worktrees.md"
+printf '%s\n' '# Local Worktree Runbook' >"$target/docs/runbooks/parallel-agent-worktrees.md"
 rc=0
 output="$(run_update_project "$target" 2>&1)" || rc=$?
 assert_exit_code 0 "$rc" "update-project runbook-seed exits 0"

--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -21,15 +21,15 @@ usage() {
 expand_path() {
   local p="$1"
   case "$p" in
-    "~")
+    \~)
       printf '%s\n' "$HOME"
       ;;
-    "~/"*)
-      printf '%s/%s\n' "$HOME" "${p#~/}"
+    \~/*)
+      printf '%s/%s\n' "$HOME" "${p#\~/}"
       ;;
-    "/~/"*)
+    /\~/*)
       # Common typo: /~/path should usually be ~/path.
-      printf '%s/%s\n' "$HOME" "${p#/~/}"
+      printf '%s/%s\n' "$HOME" "${p#/\~/}"
       ;;
     *)
       printf '%s\n' "$p"
@@ -80,7 +80,7 @@ for arg in "$@"; do
     --sync-coding-standards)
       sync_coding_standards="true"
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
@@ -150,8 +150,7 @@ for required in \
   "$vault_scaffold_dir/context/handoffs/README.md" \
   "$vault_scaffold_dir/decisions/README.md" \
   "$vault_scaffold_dir/daily/README.md" \
-  "$vault_scaffold_dir/Templates/Decision Record.md"
-do
+  "$vault_scaffold_dir/Templates/Decision Record.md"; do
   if [[ ! -f "$required" ]]; then
     echo "Error: missing scaffold file: $required"
     exit 1
@@ -186,7 +185,7 @@ validate_write_path() {
   local current_path="$destination_path"
 
   case "$destination_path" in
-    "$canonical_repo_path"|"$canonical_repo_path"/*) ;;
+    "$canonical_repo_path" | "$canonical_repo_path"/*) ;;
     *)
       return 2
       ;;
@@ -423,7 +422,7 @@ migrate_legacy_context_log_if_needed() {
   layout="$(classify_context_log_layout "$file_path")"
 
   case "$layout" in
-    missing|current)
+    missing | current)
       return
       ;;
     unknown)
@@ -577,7 +576,7 @@ collect_missing_managed_gitignore_lines() {
 
       missing_block_lines+=("$line")
       missing_pattern_count=$((missing_pattern_count + 1))
-    done <<< "$block"
+    done <<<"$block"
 
     # Skip orphaned comments when the ignore patterns already exist.
     if [[ "$missing_pattern_count" -eq 0 ]]; then
@@ -884,11 +883,11 @@ ensure_managed_gitignore_entries() {
     cp -p "$gitignore_path" "$backup_path"
     backed_up=$((backed_up + 1))
   else
-    : > "$gitignore_path"
+    : >"$gitignore_path"
   fi
 
   for line in "${missing_lines[@]}"; do
-    printf '%s\n' "$line" >> "$gitignore_path"
+    printf '%s\n' "$line" >>"$gitignore_path"
   done
 
   if [[ "$existed" == "true" ]]; then


### PR DESCRIPTION
Refs #99

## Summary

Adds a lightweight shell style/static check path for the template repository. The new local command discovers the tracked shell surface, runs syntax checks, ShellCheck, and shfmt drift checks, and keeps regression checks separate from style checks.

## Changed Areas

- `scripts/check-style.sh`: new single entrypoint for shell syntax, ShellCheck, and shfmt checks, including explicit target discovery, shebang-based hook detection, `--fix` mode, and missing-tool guidance.
- `.github/workflows/style-check.yml`: new dedicated CI workflow that installs pinned ShellCheck `v0.11.0` and shfmt `v3.13.1`, verifies both downloads with SHA-256 digests, then runs the same local command.
- `README.md`: documents when to run the command, local prerequisites for macOS and Ubuntu, CI pins, checksum verification, and the warning-level ShellCheck/shfmt policy.
- Shell scripts and hook assets: applied `shfmt -i 2 -ci` cleanup and fixed warning-level ShellCheck findings needed for the new check to pass.
- `scripts/test-path-expansion.sh`: adds regression coverage for `new-project.sh` and `update-project.sh` repo path expansion for `~`, `~/...`, `/~/...`, and absolute paths.
- `scripts/test-session-metadata-hook.sh`: keeps the new dry-run output assertion that consumes and validates the previously unused `dryrun_output` value.

## Review Feedback Addressed

- Added explicit regression coverage for the `expand_path` fix so literal `~/...` inputs do not regress to `$HOME/~/...`.
- Kept and documented the dry-run message assertion as a real behavior check rather than treating it as formatting-only cleanup.
- Added checksum verification for downloaded CI tool binaries.
- Added concrete Ubuntu local install guidance for ShellCheck and shfmt.

## Verification Loop

Passed:

- `SHELLCHECK_BIN=/tmp/agent-vault-style-tools/shellcheck-v0.11.0/shellcheck SHFMT_BIN=/tmp/agent-vault-style-tools/shfmt_v3.13.1_darwin_arm64 bash scripts/check-style.sh`
- `bash scripts/check-policy-mirrors.sh`
- `bash scripts/test-gitignore-management.sh`
- `bash scripts/test-coding-standards-sync.sh`
- `bash scripts/test-decision-template-sync.sh`
- `bash scripts/test-session-metadata-hook.sh`
- `bash scripts/test-main-push-gate.sh`
- `bash scripts/test-path-expansion.sh`
- `bash scripts/test-new-worktree.sh`
- `bash scripts/test-remove-worktree.sh`
- `bash scripts/test-worktree-helper-sync.sh`
- `git diff --check`
- `git diff --cached --check`

Also verified that `bash scripts/check-style.sh` without local tools fails with actionable install guidance when `shellcheck` and `shfmt` are not installed on PATH.

## Risks and Rollback

- Main risk is review noise from the first formatting pass, especially in the scaffold worktree helper scripts. The cleanup is limited to the shell target set and covered by existing regression tests.
- CI uses pinned tool versions and pinned digests so future rule, formatting, or binary changes require an intentional workflow update.
- Rollback is straightforward: revert the PR to remove the workflow, local command, documentation, regression test, and associated formatting cleanup.

## Docs Consistency

`README.md` was updated. No `docs/design.md` impact.