### PR TITLE
Load lessons at session start

### DIFF
--- a/.github/workflows/scaffold-regression-checks.yml
+++ b/.github/workflows/scaffold-regression-checks.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     paths:
       - "README.md"
+      - "docs/**"
       - "scaffold/agent-vault/**"
+      - "scaffold/root/*.md"
       - "scaffold/root/scripts/**"
       - "scaffold/root/docs/runbooks/**"
       - "scripts/new-project.sh"
@@ -14,6 +16,7 @@ on:
       - "scripts/test-decision-template-sync.sh"
       - "scripts/test-session-metadata-hook.sh"
       - "scripts/test-main-push-gate.sh"
+      - "scripts/test-session-start-load-contract.sh"
       - "scripts/test-path-expansion.sh"
       - "scripts/test-new-worktree.sh"
       - "scripts/test-remove-worktree.sh"
@@ -24,7 +27,9 @@ on:
       - main
     paths:
       - "README.md"
+      - "docs/**"
       - "scaffold/agent-vault/**"
+      - "scaffold/root/*.md"
       - "scaffold/root/scripts/**"
       - "scaffold/root/docs/runbooks/**"
       - "scripts/new-project.sh"
@@ -34,6 +39,7 @@ on:
       - "scripts/test-decision-template-sync.sh"
       - "scripts/test-session-metadata-hook.sh"
       - "scripts/test-main-push-gate.sh"
+      - "scripts/test-session-start-load-contract.sh"
       - "scripts/test-path-expansion.sh"
       - "scripts/test-new-worktree.sh"
       - "scripts/test-remove-worktree.sh"
@@ -57,6 +63,8 @@ jobs:
         run: bash scripts/test-session-metadata-hook.sh
       - name: Verify main push metadata gate
         run: bash scripts/test-main-push-gate.sh
+      - name: Verify session-start load contract
+        run: bash scripts/test-session-start-load-contract.sh
       - name: Verify path expansion handling
         run: bash scripts/test-path-expansion.sh
       - name: Verify worktree creation helper

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ This repo should stay template-only. Do not store project-specific session logs 
 
 If you want changes to propagate to future projects, edit files under `scaffold/agent-vault/` and `scaffold/root/`.
 
+Design notes for this template repo live under `docs/`. Start with
+`docs/session-start-load-contract.md` when changing agent startup behavior,
+agent entrypoints, or generated-project memory loading.
+
 ## Policy Mirror Drift Checks
 This repository intentionally keeps three mirrored policy blocks for compatibility:
 - `AGENTS.md` mirrors the review section from `scaffold/agent-vault/review-policy.md` (with a repo-local path alias normalization in the check).
@@ -126,6 +130,7 @@ Run the scaffold regression scripts locally when changing bootstrap, sync, or tr
 - `bash scripts/test-decision-template-sync.sh`
 - `bash scripts/test-session-metadata-hook.sh`
 - `bash scripts/test-main-push-gate.sh`
+- `bash scripts/test-session-start-load-contract.sh`
 - `bash scripts/test-path-expansion.sh`
 - `bash scripts/test-new-worktree.sh`
 - `bash scripts/test-remove-worktree.sh`
@@ -259,7 +264,7 @@ Generated projects get a starter `docs/design.md` that uses Mermaid fenced code 
 `new-project.sh` creates `<repo-path>/agent-vault/` with:
 - `shared-rules.md` (single source of truth for implementation rules)
 - `review-policy.md` (single source of truth for PR review guidelines, including required format for responding to review feedback)
-- `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` (policy files; `agent-vault/CLAUDE.md` and `agent-vault/GEMINI.md` import `shared-rules.md`, `project-context.md`, and `project-commands.md`; root wrappers import `review-policy.md`; and `AGENTS.md` inlines review guidance)
+- `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` (policy files; `agent-vault/CLAUDE.md` and `agent-vault/GEMINI.md` import `shared-rules.md`, `project-context.md`, `project-commands.md`, and `lessons.md`; root wrappers import `review-policy.md`; and `AGENTS.md` inlines review guidance)
 - Compatibility note: `AGENTS.md` files intentionally inline mirrored policy content for Codex review-path compatibility; this duplication is expected, but mirrored files should stay synchronized.
 - `README.md`
 - `context-log.md`
@@ -275,7 +280,7 @@ Generated projects get a starter `docs/design.md` that uses Mermaid fenced code 
 - `Templates/` (copied from template source; instantiated notes belong outside this folder)
 
 It also creates project-root files when missing:
-- `<repo-path>/AGENTS.md` -> contains PR review guidance (inline) for Codex GitHub reviews and points workflow execution to `agent-vault/AGENTS.md`
+- `<repo-path>/AGENTS.md` -> contains PR review guidance (inline) for Codex GitHub reviews, points workflow execution to `agent-vault/AGENTS.md`, and directly tells Codex to read `agent-vault/lessons.md` at session start
 - `<repo-path>/CLAUDE.md` -> imports `agent-vault/CLAUDE.md` and `agent-vault/review-policy.md`
 - `<repo-path>/GEMINI.md` -> imports `agent-vault/GEMINI.md` and `agent-vault/review-policy.md`
 - `<repo-path>/docs/design.md` -> starter architecture/design document with embedded Mermaid diagrams

--- a/docs/session-start-load-contract.md
+++ b/docs/session-start-load-contract.md
@@ -1,0 +1,86 @@
+# Session Start Load Contract
+
+This document records how generated `agent-vault` projects make startup
+instructions and durable memory visible to common coding agents.
+
+## Purpose
+
+Generated projects use several agent entrypoints because Codex, Claude, Gemini,
+and other tools do not load Markdown instructions the same way. This contract
+keeps the scaffold explicit about which files are force-loaded by the host and
+which files still depend on an agent following the session-start protocol.
+
+The current policy is intentionally conservative: use native import mechanisms
+where they exist, keep project-owned memory in `agent-vault/`, and defer
+generated composition until the host-by-host behavior is specified more fully.
+
+## Generated Entrypoints
+
+| Agent surface | Generated entrypoint | Current load behavior |
+| --- | --- | --- |
+| Codex | root `AGENTS.md` | Codex loads `AGENTS.md` files along the current working-directory ancestry. A normal repo-root launch receives root `AGENTS.md`, not nested `agent-vault/AGENTS.md`. |
+| Claude Code | root `CLAUDE.md` | Root wrapper imports `agent-vault/CLAUDE.md`; `agent-vault/CLAUDE.md` imports shared workflow files. |
+| Gemini CLI | root `GEMINI.md` | Root wrapper imports `agent-vault/GEMINI.md`; `agent-vault/GEMINI.md` imports shared workflow files. |
+
+## File Categories
+
+| Category | Files | Contract |
+| --- | --- | --- |
+| Force-loaded or imported workflow | `agent-vault/CLAUDE.md`, `agent-vault/GEMINI.md`, their imported files | Use native imports where the host supports them. |
+| Codex root startup instructions | root `AGENTS.md` | Keep concise instructions that must be visible when Codex starts from the repo root. |
+| Session-start protocol reads | `agent-vault/README.md`, `context-log.md`, `plan.md`, `coding-standards.md`, `project-context.md`, `project-commands.md`, `open-questions.md`, `decision-log.md`, `lessons.md` | Agents are instructed to read these at session start or when relevant. |
+| Runtime project memory | `agent-vault/context-log.md`, `agent-vault/lessons.md`, daily notes, handoffs, decision records | Seed missing files, but do not overwrite project-owned content during normal updates. |
+| Referenced archives | older daily notes, older handoffs, detailed decision records | Read when the current task or current index points to them. |
+
+## Current `lessons.md` Decision
+
+For issue #102, the accepted implementation path is Option A:
+
+- `agent-vault/CLAUDE.md` imports `@./lessons.md`.
+- `agent-vault/GEMINI.md` imports `@./lessons.md`.
+- root `AGENTS.md` directly tells Codex to read `agent-vault/lessons.md` at session start.
+- `agent-vault/lessons.md` remains project-owned runtime memory and is not
+  mirrored or generated into root `AGENTS.md`.
+
+This gives Claude and Gemini native import-based loading while reducing Codex
+indirection from root `AGENTS.md` to `lessons.md`.
+
+## Accepted Residual Risk
+
+Codex remains protocol-dependent for `agent-vault/lessons.md`. The root
+`AGENTS.md` instruction is visible at startup, but Codex must still execute the
+instruction and read the separate file. This does not fully close the failure
+mode where an agent skips session-start reads.
+
+That risk is accepted for #102 because generated composition would add a new
+sync surface across `scripts/new-project.sh`, `scripts/update-project.sh`,
+managed root wrappers, backup behavior, dry-run behavior, and drift checks. The
+larger decision belongs in #103, where the project can decide whether to add:
+
+- generated root `AGENTS.md` composition from `agent-vault/lessons.md`
+- a bounded startup lesson digest
+- a full lesson mirror
+- a skill or search workflow for long lesson archives
+- a host-by-host load contract for other always-on files
+
+## Update Script Implications
+
+`scripts/new-project.sh` and `scripts/update-project.sh` currently treat
+`agent-vault/lessons.md` as project-owned memory:
+
+- `new-project.sh` copies the scaffold placeholder into new projects.
+- `update-project.sh` seeds `agent-vault/lessons.md` only when it is missing.
+- normal updates must not overwrite accumulated project lessons.
+
+If generated composition is adopted later, the implementation needs a dedicated
+render step rather than raw file copying:
+
+1. Read the scaffold root `AGENTS.md` template.
+2. Read the target project's current `agent-vault/lessons.md`.
+3. Render a managed generated block or digest into the root `AGENTS.md` output.
+4. Preserve existing backup, dry-run, symlink, and managed-marker behavior.
+5. Add tests that prove the rendered root `AGENTS.md` stays in sync with the
+   project-owned source.
+
+Until that mechanism exists, do not duplicate `lessons.md` content manually into
+root `AGENTS.md`.

--- a/scaffold/agent-vault/AGENTS.md
+++ b/scaffold/agent-vault/AGENTS.md
@@ -7,7 +7,7 @@
 
 ## Compatibility Note
 - `agent-vault/AGENTS.md` intentionally mirrors `agent-vault/shared-rules.md` for Codex compatibility.
-- `agent-vault/CLAUDE.md` and `agent-vault/GEMINI.md` import `shared-rules.md`.
+- `agent-vault/CLAUDE.md` and `agent-vault/GEMINI.md` import `shared-rules.md` and `lessons.md`.
 - Do not flag duplication itself; only flag drift between mirrored policy files.
 
 ## PR Feedback Response

--- a/scaffold/agent-vault/CLAUDE.md
+++ b/scaffold/agent-vault/CLAUDE.md
@@ -3,3 +3,4 @@
 @./shared-rules.md
 @./project-context.md
 @./project-commands.md
+@./lessons.md

--- a/scaffold/agent-vault/GEMINI.md
+++ b/scaffold/agent-vault/GEMINI.md
@@ -3,3 +3,4 @@
 @./shared-rules.md
 @./project-context.md
 @./project-commands.md
+@./lessons.md

--- a/scaffold/agent-vault/shared-rules.md
+++ b/scaffold/agent-vault/shared-rules.md
@@ -2,7 +2,7 @@
 
 ## Compatibility Note
 - `agent-vault/AGENTS.md` intentionally mirrors this file for Codex compatibility.
-- `agent-vault/CLAUDE.md` and `agent-vault/GEMINI.md` import this file directly.
+- `agent-vault/CLAUDE.md` and `agent-vault/GEMINI.md` import this file directly and import `agent-vault/lessons.md` separately.
 - Treat duplication as intentional; treat content drift as a defect.
 
 ## PR Feedback Response

--- a/scaffold/root/AGENTS.md
+++ b/scaffold/root/AGENTS.md
@@ -12,6 +12,7 @@ Project agent rules are defined in `agent-vault/AGENTS.md`.
 Read that file before making changes.
 Read `agent-vault/project-context.md` for repository architecture and runtime behavior.
 Read `agent-vault/project-commands.md` for setup, test, and operational commands.
+At session start, read `agent-vault/lessons.md` if it exists.
 
 ## PR Authoring
 - For agent-authored pull requests, follow `agent-vault/AGENTS.md` section `PR Authoring Standards`.

--- a/scripts/test-session-start-load-contract.sh
+++ b/scripts/test-session-start-load-contract.sh
@@ -42,6 +42,13 @@ assert_file_contains "$generated_repo/agent-vault/CLAUDE.md" "@./lessons.md"
 assert_file_contains "$generated_repo/agent-vault/GEMINI.md" "@./lessons.md"
 assert_file_contains "$generated_repo/AGENTS.md" 'At session start, read `agent-vault/lessons.md` if it exists.'
 
+perl -0pi -e 's/\Q@.\/lessons.md\E\n//' "$generated_repo/agent-vault/CLAUDE.md"
+perl -0pi -e 's/\QAt session start, read `agent-vault\/lessons.md` if it exists.\E\n//' "$generated_repo/AGENTS.md"
+"$repo_root/scripts/update-project.sh" "$generated_repo" >/dev/null
+
+assert_file_contains "$generated_repo/agent-vault/CLAUDE.md" "@./lessons.md"
+assert_file_contains "$generated_repo/AGENTS.md" 'At session start, read `agent-vault/lessons.md` if it exists.'
+
 "$repo_root/scripts/check-policy-mirrors.sh" >/dev/null
 
 echo "session-start load contract regression checks passed."

--- a/scripts/test-session-start-load-contract.sh
+++ b/scripts/test-session-start-load-contract.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/agent-vault-load-contract-test.XXXXXX")"
+
+cleanup() {
+  rm -rf "$tmp_root"
+}
+
+trap cleanup EXIT
+
+assert_file_contains() {
+  local file_path="$1"
+  local expected_text="$2"
+
+  if ! grep -Fqx "$expected_text" "$file_path"; then
+    echo "Expected line not found in $file_path: $expected_text" >&2
+    echo "File contents:" >&2
+    sed -n '1,80p' "$file_path" >&2
+    exit 1
+  fi
+}
+
+init_repo() {
+  local repo_path="$1"
+
+  mkdir -p "$repo_path"
+  git -C "$repo_path" init >/dev/null
+}
+
+assert_file_contains "$repo_root/scaffold/agent-vault/CLAUDE.md" "@./lessons.md"
+assert_file_contains "$repo_root/scaffold/agent-vault/GEMINI.md" "@./lessons.md"
+assert_file_contains "$repo_root/scaffold/root/AGENTS.md" 'At session start, read `agent-vault/lessons.md` if it exists.'
+
+generated_repo="$tmp_root/generated"
+init_repo "$generated_repo"
+"$repo_root/scripts/new-project.sh" "load-contract-test" "$generated_repo" >/dev/null
+
+assert_file_contains "$generated_repo/agent-vault/CLAUDE.md" "@./lessons.md"
+assert_file_contains "$generated_repo/agent-vault/GEMINI.md" "@./lessons.md"
+assert_file_contains "$generated_repo/AGENTS.md" 'At session start, read `agent-vault/lessons.md` if it exists.'
+
+"$repo_root/scripts/check-policy-mirrors.sh" >/dev/null
+
+echo "session-start load contract regression checks passed."


### PR DESCRIPTION
> 🤖 Prepared by Codex GPT-5 · via Codex CLI

## Summary
- Problem: `lessons.md` was only referenced by session-start protocol, so Claude/Gemini were not using their native import path and Codex had an extra indirection before reading lessons.
- Approach: Add native `@./lessons.md` imports for Claude/Gemini, add a direct root Codex startup instruction, document the accepted Codex residual risk for #102, and add regression coverage for both new-project and update-project paths.
- Outcome: Generated projects now surface lessons more directly while deferring generated `AGENTS.md` composition decisions to #103.

## Changes
- `scaffold/agent-vault/CLAUDE.md`, `scaffold/agent-vault/GEMINI.md`: import `@./lessons.md`.
- `scaffold/root/AGENTS.md`: directly instruct Codex to read `agent-vault/lessons.md` at session start.
- `docs/session-start-load-contract.md`: documents entrypoints, file categories, the #102 Option A decision, residual Codex risk, and future update-script implications.
- `scripts/test-session-start-load-contract.sh`: adds regression coverage for scaffold files, generated-project output, and update-project restoration of removed lessons startup lines.
- `.github/workflows/scaffold-regression-checks.yml`: runs the new regression test and triggers on repo docs/root wrapper changes.
- `README.md`, `scaffold/agent-vault/AGENTS.md`, `scaffold/agent-vault/shared-rules.md`: update documentation and compatibility notes.

## Verification Loop
- Build / package: Not applicable.
- Typecheck / static analysis: `bash scripts/check-style.sh` - passed.
- Lint / format validation: `git diff --check` - passed.
- Tests / coverage: `bash scripts/test-session-start-load-contract.sh` - passed.
- Tests / coverage: full scaffold regression script set - passed after the update-project round-trip was added.
- Security / secrets / workflow checks: workflow path-filter self-review found and fixed the missing `scaffold/root/*.md` trigger for the new regression coverage.
- Diff review: self-review completed; no remaining findings.
- Not run: no external CI result after commit `64a78e0` yet; pushed for CI validation.

## Risks and Rollback
- Risk: Codex remains protocol-dependent for actually reading `agent-vault/lessons.md`; this is the accepted #102 Option A trade-off.
- Mitigation: direct root instruction reduces indirection, and `docs/session-start-load-contract.md` records the residual risk and #103 follow-up.
- Rollback: revert this PR's commits to restore the previous scaffold behavior.

## Docs Consistency
- `docs/session-start-load-contract.md`: Added.
- `README.md`: Updated to reference the new doc, import graph, generated root instruction, and regression check.

## Review Feedback Mapping
| # | Finding | Status | Evidence / Rationale |
|---|---------|--------|----------------------|
| 1 | Amend #102 scope to Option A and document Codex residual risk | Resolved | `932bec6`; `docs/session-start-load-contract.md`; issue thread comment updates acceptance criteria. |
| 2 | Make the root Codex startup note mandatory | Resolved | `932bec6`; `scaffold/root/AGENTS.md`. |
| 3 | Add regression coverage for imports/root instruction | Resolved | `932bec6`; `scripts/test-session-start-load-contract.sh`; `.github/workflows/scaffold-regression-checks.yml`. |
| 4 | Update pre-anchor Compatibility Note in `scaffold/agent-vault/AGENTS.md` | Resolved | `932bec6`; `scaffold/agent-vault/AGENTS.md`; `scaffold/agent-vault/shared-rules.md`. |
| 5 | Add update-project round-trip coverage for existing managed projects | Resolved | `64a78e0`; `scripts/test-session-start-load-contract.sh`; test removes lessons startup lines, reruns `update-project.sh`, and asserts restoration. |

## Follow-Ups
- [ ] #103: decide whether Codex should eventually use generated root `AGENTS.md` composition, a bounded startup digest, or another host-specific load mechanism.