### PR TITLE
Add Grok Build worktree compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Public template repository for generating a per-project `agent-vault/` folder.
 MIT. See `LICENSE`.
 
 ## What This Is
-This repo is a reusable scaffold for teams using AI coding agents (for example Codex, Claude, and Gemini CLI) and Obsidian.
+This repo is a reusable scaffold for teams using AI coding agents (for example Codex, Claude, Gemini CLI, and Grok Build) and Obsidian.
 
 It gives each code repository a standard `agent-vault/` directory with Markdown files for:
 - shared context

--- a/docs/session-start-load-contract.md
+++ b/docs/session-start-load-contract.md
@@ -6,9 +6,10 @@ instructions and durable memory visible to common coding agents.
 ## Purpose
 
 Generated projects use several agent entrypoints because Codex, Claude, Gemini,
-and other tools do not load Markdown instructions the same way. This contract
-keeps the scaffold explicit about which files are force-loaded by the host and
-which files still depend on an agent following the session-start protocol.
+Grok Build, and other tools do not load Markdown instructions the same way.
+This contract keeps the scaffold explicit about which files are force-loaded by
+the host and which files still depend on an agent following the session-start
+protocol.
 
 The current policy is intentionally conservative: use native import mechanisms
 where they exist, keep project-owned memory in `agent-vault/`, and defer
@@ -23,13 +24,14 @@ See `docs/session-start-load-measurements.md` for the current evidence record.
 | Codex | root `AGENTS.md` | Codex loads `AGENTS.md` files along the current working-directory ancestry. A normal repo-root launch receives root `AGENTS.md`, not nested `agent-vault/AGENTS.md`. |
 | Claude Code | root `CLAUDE.md` | Root wrapper imports `agent-vault/CLAUDE.md`; `agent-vault/CLAUDE.md` imports shared workflow files. |
 | Gemini CLI | root `GEMINI.md` | Root wrapper imports `agent-vault/GEMINI.md`; `agent-vault/GEMINI.md` imports shared workflow files. |
+| Grok Build | root `AGENTS.md` | Grok documents `AGENTS.md` family discovery from cwd to repo root and Claude-compatible instruction-file discovery, including `CLAUDE.md` ([xAI docs](https://docs.x.ai/build/features/skills-plugins-marketplaces)). For generated projects, root `AGENTS.md` is canonical for Grok. `CLAUDE.md` may also be discovered, but Claude-style `@` import expansion is unmeasured and not relied on. On overlap, `AGENTS.md` is authoritative. Local startup and protocol-read measurements are pending. |
 
 ## File Categories
 
 | Category | Files | Contract |
 | --- | --- | --- |
 | Force-loaded or imported workflow | `agent-vault/CLAUDE.md`, `agent-vault/GEMINI.md`, their imported files | Use native imports where the host supports them. |
-| Codex root startup instructions | root `AGENTS.md` | Keep concise instructions that must be visible when Codex starts from the repo root. |
+| `AGENTS.md` root startup instructions | root `AGENTS.md` | Keep concise instructions that must be visible when Codex or Grok starts from the repo root. |
 | Session-start protocol reads | `agent-vault/README.md`, `context-log.md`, `plan.md`, `coding-standards.md`, `project-context.md`, `project-commands.md`, `open-questions.md`, `decision-log.md`, `lessons.md` | Agents are instructed to read these at session start or when relevant. |
 | Runtime project memory | `agent-vault/context-log.md`, `agent-vault/lessons.md`, daily notes, handoffs, decision records | Seed missing files, but do not overwrite project-owned content during normal updates. |
 | Referenced archives | older daily notes, older handoffs, detailed decision records | Read when the current task or current index points to them. |

--- a/scaffold/agent-vault/project-commands.md
+++ b/scaffold/agent-vault/project-commands.md
@@ -34,6 +34,9 @@ update this file when the canonical workflow changes.
 # Create one issue-scoped worktree for Gemini
 ./scripts/new-worktree.sh --agent gemini --issue 125 --slug docs-followup
 
+# Create one issue-scoped worktree for Grok Build
+./scripts/new-worktree.sh --agent grok --issue 126 --slug grok-build-support
+
 # After merge, remove the worktree from the main checkout or another safe cwd
 ./scripts/remove-worktree.sh --branch codex/123-feature-slice --delete-branch
 ```

--- a/scaffold/root/docs/runbooks/parallel-agent-worktrees.md
+++ b/scaffold/root/docs/runbooks/parallel-agent-worktrees.md
@@ -48,6 +48,7 @@ Other agent examples:
 ```bash
 ./scripts/new-worktree.sh --agent claude --issue 124 --slug review-cleanup
 ./scripts/new-worktree.sh --agent gemini --issue 125 --slug docs-followup
+./scripts/new-worktree.sh --agent grok --issue 126 --slug grok-build-support
 ```
 
 By default the helper creates repo-local worktrees under:
@@ -59,10 +60,11 @@ By default the helper creates repo-local worktrees under:
 For a repository named `example-app`, the layout is:
 
 ```text
-example-app/                                      # main checkout
-example-app/.worktrees/codex-123-feature-slice/   # issue worktree
-example-app/.worktrees/claude-124-review-cleanup/ # issue worktree
-example-app/.worktrees/gemini-125-docs-followup/  # issue worktree
+example-app/                                        # main checkout
+example-app/.worktrees/codex-123-feature-slice/     # issue worktree
+example-app/.worktrees/claude-124-review-cleanup/   # issue worktree
+example-app/.worktrees/gemini-125-docs-followup/    # issue worktree
+example-app/.worktrees/grok-126-grok-build-support/ # issue worktree
 ```
 
 The helper creates:
@@ -71,7 +73,7 @@ The helper creates:
 - a worktree directory named like `codex-123-feature-slice`
 
 Then it prints the `cd` command and a best-effort launch hint such as `codex`,
-`claude`, or `gemini`.
+`claude`, `gemini`, or `grok`.
 
 ## Custom Worktree Root
 Use `--root` to place worktrees somewhere else:
@@ -125,6 +127,9 @@ claude
 
 cd .worktrees/gemini-125-docs-followup
 gemini
+
+cd .worktrees/grok-126-grok-build-support
+grok
 ```
 
 Many agent clients treat the launch directory as the active writable workspace.
@@ -218,6 +223,9 @@ the project commands:
 
 # Create one issue-scoped worktree for Gemini
 ./scripts/new-worktree.sh --agent gemini --issue 125 --slug docs-followup
+
+# Create one issue-scoped worktree for Grok Build
+./scripts/new-worktree.sh --agent grok --issue 126 --slug grok-build-support
 
 # After merge, remove the worktree from the main checkout or another safe cwd
 ./scripts/remove-worktree.sh --branch codex/123-feature-slice --delete-branch

--- a/scaffold/root/scripts/new-worktree.sh
+++ b/scaffold/root/scripts/new-worktree.sh
@@ -20,7 +20,7 @@ Usage: $0 --agent NAME --issue NUMBER [--slug TEXT] [--base REF] [--root DIR]
 Create or reuse one issue-scoped worktree for one writing agent.
 
 Options:
-  --agent NAME   Agent label, for example: codex, claude, gemini
+  --agent NAME   Agent label, for example: codex, claude, gemini, grok
   --issue N      Issue number
   --slug TEXT    Optional short slug, for example: feature-slice
   --base REF     Optional base ref. Defaults to origin/main when available,
@@ -37,6 +37,7 @@ Examples:
   $0 --agent codex --issue 123 --slug feature-slice
   $0 --agent claude --issue 124 --slug review-cleanup
   $0 --agent gemini --issue 125 --slug docs-followup
+  $0 --agent grok --issue 126 --slug grok-build-support
 EOF
 }
 
@@ -106,6 +107,9 @@ launch_hint() {
       ;;
     gemini*)
       printf 'gemini\n'
+      ;;
+    grok*)
+      printf 'grok\n'
       ;;
     *)
       printf '\n'

--- a/scripts/test-new-worktree.sh
+++ b/scripts/test-new-worktree.sh
@@ -235,7 +235,25 @@ output="$(run_new_worktree "$working" --agent gemini --issue 125 --slug docs-fol
 assert_exit_code 0 "$rc" "gemini-worktree exits 0"
 assert_output_contains "$output" "gemini" "gemini-worktree prints gemini hint"
 
-# --- Test 9: Stale worktree metadata is pruned and recreated ---
+# --- Test 9: Grok launch hint is supported ---
+working="$(setup_repo repo-grok)"
+rc=0
+output="$(run_new_worktree "$working" --agent "Grok Build" --issue 126 --slug grok-build-support 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "grok-worktree exits 0"
+expected_path="$tmp_root/wt/grok-build-126-grok-build-support"
+assert_path_exists "$expected_path" "grok-worktree created normalized path"
+assert_path_under_tmp "$expected_path" "grok-worktree stays inside temp root"
+branch_name="$(git -C "$expected_path" branch --show-current)"
+if [[ "$branch_name" == "grok-build/126-grok-build-support" ]]; then
+  echo "PASS: grok-worktree branch name"
+  passed=$((passed + 1))
+else
+  echo "FAIL: grok-worktree branch name (got $branch_name)" >&2
+  failed=$((failed + 1))
+fi
+assert_output_contains "$output" $'\n  grok' "grok-worktree prints grok launch hint"
+
+# --- Test 10: Stale worktree metadata is pruned and recreated ---
 working="$(setup_repo repo4)"
 rc=0
 output="$(run_new_worktree "$working" --agent codex --issue 126 --slug stale-recreate 2>&1)" || rc=$?
@@ -249,26 +267,26 @@ assert_exit_code 0 "$rc" "stale-worktree recreate exits 0"
 assert_output_contains "$output" "Created worktree:" "stale-worktree rerun recreates path"
 assert_path_exists "$expected_path" "stale-worktree recreated target path"
 
-# --- Test 10: Missing required args fail clearly ---
+# --- Test 11: Missing required args fail clearly ---
 working="$(setup_repo repo5)"
 rc=0
 output="$(run_new_worktree "$working" --agent codex 2>&1)" || rc=$?
 assert_exit_code 1 "$rc" "missing-issue exits 1"
 assert_output_contains "$output" "--issue is required" "missing-issue shows error"
 
-# --- Test 11: Invalid issue values fail clearly ---
+# --- Test 12: Invalid issue values fail clearly ---
 rc=0
 output="$(run_new_worktree "$working" --agent codex --issue abc 2>&1)" || rc=$?
 assert_exit_code 1 "$rc" "non-numeric-issue exits 1"
 assert_output_contains "$output" "--issue must be numeric" "non-numeric-issue shows error"
 
-# --- Test 12: Agent values that normalize to empty fail clearly ---
+# --- Test 13: Agent values that normalize to empty fail clearly ---
 rc=0
 output="$(run_new_worktree "$working" --agent "!!!" --issue 127 2>&1)" || rc=$?
 assert_exit_code 1 "$rc" "empty-normalized-agent exits 1"
 assert_output_contains "$output" "--agent must contain letters or numbers" "empty-normalized-agent shows error"
 
-# --- Test 13: Bad base refs fail before creating the worktree root ---
+# --- Test 14: Bad base refs fail before creating the worktree root ---
 working="$(setup_repo repo6)"
 bad_base_root="$tmp_root/bad-base-root"
 rc=0

--- a/scripts/test-new-worktree.sh
+++ b/scripts/test-new-worktree.sh
@@ -253,7 +253,25 @@ else
 fi
 assert_output_contains "$output" $'\n  grok' "grok-worktree prints grok launch hint"
 
-# --- Test 10: Stale worktree metadata is pruned and recreated ---
+# --- Test 10: Lowercase Grok agent creates canonical grok branch and path ---
+working="$(setup_repo repo-grok-lowercase)"
+rc=0
+output="$(run_new_worktree "$working" --agent grok --issue 127 --slug lowercase-grok 2>&1)" || rc=$?
+assert_exit_code 0 "$rc" "grok-lowercase exits 0"
+expected_path="$tmp_root/wt/grok-127-lowercase-grok"
+assert_path_exists "$expected_path" "grok-lowercase created canonical path"
+assert_path_under_tmp "$expected_path" "grok-lowercase stays inside temp root"
+branch_name="$(git -C "$expected_path" branch --show-current)"
+if [[ "$branch_name" == "grok/127-lowercase-grok" ]]; then
+  echo "PASS: grok-lowercase branch name"
+  passed=$((passed + 1))
+else
+  echo "FAIL: grok-lowercase branch name (got $branch_name)" >&2
+  failed=$((failed + 1))
+fi
+assert_output_contains "$output" $'\n  grok' "grok-lowercase prints grok launch hint"
+
+# --- Test 11: Stale worktree metadata is pruned and recreated ---
 working="$(setup_repo repo4)"
 rc=0
 output="$(run_new_worktree "$working" --agent codex --issue 126 --slug stale-recreate 2>&1)" || rc=$?
@@ -267,26 +285,26 @@ assert_exit_code 0 "$rc" "stale-worktree recreate exits 0"
 assert_output_contains "$output" "Created worktree:" "stale-worktree rerun recreates path"
 assert_path_exists "$expected_path" "stale-worktree recreated target path"
 
-# --- Test 11: Missing required args fail clearly ---
+# --- Test 12: Missing required args fail clearly ---
 working="$(setup_repo repo5)"
 rc=0
 output="$(run_new_worktree "$working" --agent codex 2>&1)" || rc=$?
 assert_exit_code 1 "$rc" "missing-issue exits 1"
 assert_output_contains "$output" "--issue is required" "missing-issue shows error"
 
-# --- Test 12: Invalid issue values fail clearly ---
+# --- Test 13: Invalid issue values fail clearly ---
 rc=0
 output="$(run_new_worktree "$working" --agent codex --issue abc 2>&1)" || rc=$?
 assert_exit_code 1 "$rc" "non-numeric-issue exits 1"
 assert_output_contains "$output" "--issue must be numeric" "non-numeric-issue shows error"
 
-# --- Test 13: Agent values that normalize to empty fail clearly ---
+# --- Test 14: Agent values that normalize to empty fail clearly ---
 rc=0
 output="$(run_new_worktree "$working" --agent "!!!" --issue 127 2>&1)" || rc=$?
 assert_exit_code 1 "$rc" "empty-normalized-agent exits 1"
 assert_output_contains "$output" "--agent must contain letters or numbers" "empty-normalized-agent shows error"
 
-# --- Test 14: Bad base refs fail before creating the worktree root ---
+# --- Test 15: Bad base refs fail before creating the worktree root ---
 working="$(setup_repo repo6)"
 bad_base_root="$tmp_root/bad-base-root"
 rc=0


### PR DESCRIPTION
> 🤖 Prepared by Codex GPT-5 · via Codex CLI

## Summary
- Problem: Generated agent-vault projects did not explicitly list Grok Build as a supported agent surface, and the managed worktree helper did not print a `grok` launch hint for Grok issue worktrees.
- Approach: Add the minimum first-pass Grok Build compatibility agreed in #112: worktree launch support, generated command/runbook examples, README wording, and a session-start load-contract row.
- Outcome: Grok Build can be selected with `--agent grok`, generated docs show the command, and the load contract records root `AGENTS.md` as canonical for Grok while leaving local startup/protocol measurement to #105.

## Changes
- `scaffold/root/scripts/new-worktree.sh`: adds `grok` to help examples and prints `grok` for normalized `grok*` agents.
- `scripts/test-new-worktree.sh`: adds coverage for `--agent "Grok Build"` and lowercase `--agent grok`, including normalized branch/path behavior and printed launch hints.
- `scaffold/agent-vault/project-commands.md`: adds a Grok Build worktree command example.
- `scaffold/root/docs/runbooks/parallel-agent-worktrees.md`: adds Grok examples to the generated worktree runbook.
- `README.md`: lists Grok Build with the supported AI coding agent examples.
- `docs/session-start-load-contract.md`: adds Grok Build to generated entrypoints and records the agreed `AGENTS.md` canonical / `CLAUDE.md` discovered-but-imports-unproven contract.

## Verification Loop
- Build / package: Not applicable; scaffold/docs/helper-script change only.
- Typecheck / static analysis: `bash scripts/check-style.sh` - passed, including shell syntax and ShellCheck.
- Lint / format validation: `bash scripts/check-style.sh` - passed, including shfmt diff check.
- Tests / coverage: `bash scripts/check-policy-mirrors.sh` - passed.
- Tests / coverage: `bash scripts/test-session-start-load-contract.sh` - passed.
- Tests / coverage: `bash scripts/test-new-worktree.sh` - passed, 61 checks.
- Tests / coverage: `bash scripts/test-worktree-helper-sync.sh` - passed, 37 checks.
- Tests / coverage: `bash scripts/test-agent-memory-load-measurement.sh` - passed.
- Security / secrets / workflow checks: No auth, secrets, CI, workflow, dynamic execution, or permission-policy changes. Shell changes are limited to static `grok` launch-hint output and were covered by shell checks.
- Diff review: `git diff --check` and manual diff review - passed; no unrelated files staged.
- Not run: No live Grok protocol-read measurement; intentionally deferred to #105 per #112 discussion.

## Risks and Rollback
- Risk: The load-contract row records documented/discovered behavior before a full local startup/protocol measurement exists.
- Mitigation: The row explicitly marks local measurements pending and does not add `.grok/` assets, hooks, CI, or generated composition.
- Rollback: Revert commits `057e12b` and `19103da` to remove the Grok helper/docs/test additions.

## Docs Consistency
- `docs/design.md`: No impact; this changes generated agent workflow docs, not architecture.
- `README.md`: Updated to include Grok Build in supported-agent examples.

## Review Feedback Mapping (if applicable)
| # | Finding | Status | Evidence / Rationale |
|---|---------|--------|----------------------|
| 1 | #112 discussion converged on a smaller first PR scope. | Resolved | `057e12b`; implemented helper hint, targeted docs, load-contract row, and test coverage only. |
| 2 | Avoid relying on Grok `CLAUDE.md` `@` import expansion before measurement. | Resolved | `057e12b`; `docs/session-start-load-contract.md` states root `AGENTS.md` is canonical and `@` expansion is unmeasured/not relied on. |
| 3 | Optional PR feedback suggested direct lowercase `--agent grok` coverage. | Resolved | `19103da`; `scripts/test-new-worktree.sh` now verifies lowercase Grok creates `grok/127-lowercase-grok`, `grok-127-lowercase-grok`, and prints the `grok` launch hint. |

## Follow-Ups
- [ ] Capture `grok inspect --json` and protocol-read evidence under #105 after a real Grok Build run.