### PR TITLE
Include coding standards in Cursor rule

### DIFF
--- a/scaffold/root/.cursor/rules/agent-vault.mdc
+++ b/scaffold/root/.cursor/rules/agent-vault.mdc
@@ -12,8 +12,8 @@ a separate source of truth.
 - Follow the project-root `AGENTS.md` first. Cursor CLI also loads that file as
   a project rule.
 - Before changing files, read `agent-vault/AGENTS.md`.
-- Read `agent-vault/project-context.md`, `agent-vault/project-commands.md`, and
-  `agent-vault/lessons.md` when present.
+- Read `agent-vault/project-context.md`, `agent-vault/project-commands.md`,
+  `agent-vault/coding-standards.md`, and `agent-vault/lessons.md` when present.
 - For pull request reviews or review-feedback responses, follow the project-root
   `AGENTS.md` review policy and `agent-vault/review-policy.md`.
 - Keep substantive workflow changes in the Agent Vault scaffold sources and

--- a/scripts/test-session-start-load-contract.sh
+++ b/scripts/test-session-start-load-contract.sh
@@ -56,6 +56,7 @@ assert_file_contains "$repo_root/scaffold/agent-vault/GEMINI.md" "@./lessons.md"
 assert_file_contains "$repo_root/scaffold/root/AGENTS.md" 'At session start, read `agent-vault/lessons.md` if it exists.'
 assert_file_contains "$repo_root/scaffold/root/.cursor/rules/agent-vault.mdc" '<!-- agent-vault-managed: cursor-rule; file=.cursor/rules/agent-vault.mdc -->'
 assert_file_contains "$repo_root/scaffold/root/.cursor/rules/agent-vault.mdc" 'alwaysApply: true'
+assert_file_contains "$repo_root/scaffold/root/.cursor/rules/agent-vault.mdc" '  `agent-vault/coding-standards.md`, and `agent-vault/lessons.md` when present.'
 
 generated_repo="$tmp_root/generated"
 init_repo "$generated_repo"
@@ -66,6 +67,7 @@ assert_file_contains "$generated_repo/agent-vault/GEMINI.md" "@./lessons.md"
 assert_file_contains "$generated_repo/AGENTS.md" 'At session start, read `agent-vault/lessons.md` if it exists.'
 assert_file_contains "$generated_repo/.cursor/rules/agent-vault.mdc" '<!-- agent-vault-managed: cursor-rule; file=.cursor/rules/agent-vault.mdc -->'
 assert_file_contains "$generated_repo/.cursor/rules/agent-vault.mdc" 'alwaysApply: true'
+assert_file_contains "$generated_repo/.cursor/rules/agent-vault.mdc" '  `agent-vault/coding-standards.md`, and `agent-vault/lessons.md` when present.'
 
 perl -0pi -e 's/\Q@.\/lessons.md\E\n//' "$generated_repo/agent-vault/CLAUDE.md"
 perl -0pi -e 's/\QAt session start, read `agent-vault\/lessons.md` if it exists.\E\n//' "$generated_repo/AGENTS.md"
@@ -75,6 +77,7 @@ printf '\nlocal cursor rule edit\n' >>"$generated_repo/.cursor/rules/agent-vault
 assert_file_contains "$generated_repo/agent-vault/CLAUDE.md" "@./lessons.md"
 assert_file_contains "$generated_repo/AGENTS.md" 'At session start, read `agent-vault/lessons.md` if it exists.'
 assert_file_contains "$generated_repo/.cursor/rules/agent-vault.mdc" '<!-- agent-vault-managed: cursor-rule; file=.cursor/rules/agent-vault.mdc -->'
+assert_file_contains "$generated_repo/.cursor/rules/agent-vault.mdc" '  `agent-vault/coding-standards.md`, and `agent-vault/lessons.md` when present.'
 
 if grep -Fqx 'local cursor rule edit' "$generated_repo/.cursor/rules/agent-vault.mdc"; then
   echo "Expected update-project.sh to refresh managed Cursor rule." >&2


### PR DESCRIPTION
## Summary
- add agent-vault/coding-standards.md to the managed Cursor rule startup file list
- assert new projects and managed Cursor rule refreshes keep that startup pointer

## Validation
- bash scripts/test-session-start-load-contract.sh
- bash scripts/check-style.sh
- git diff --check