### PR TITLE
check-memory-budget: chain budget net of per-file exceptions; deprecate @chain (#119 PR-A)

### DIFF
--- a/docs/memory-budgets.md
+++ b/docs/memory-budgets.md
@@ -63,9 +63,14 @@ Design choices that matter:
   over its per-file budget when shrinking it further would mean deleting a live
   invariant. Record it in an exceptions file (one `path<TAB>reason` line per
   entry); the report prints the reason and the file is not a strict violation.
-  An excepted file still counts toward the `@`-chain total (it still loads into
-  context), so an intentional chain-total overage is documented separately with
-  the reserved path `@chain` (or `chain_exception` in the config).
+  The `@`-chain total is checked **net of** these per-file exceptions: an
+  excepted file still loads into context, but it is subtracted from the chain
+  total, so an approved oversized file does not consume the chain budget while
+  the chain budget keeps governing all non-excepted always-on content. (The
+  legacy reserved `@chain` path / `chain_exception=` config is still parsed but
+  **deprecated** — it was unbounded and no longer suppresses chain overage;
+  express an approved residual via per-file exceptions or a configured
+  `chain_budget`.)
 
 ## Budgets and per-repo configuration
 
@@ -97,10 +102,9 @@ chain_budget=120000
 # protocol_read=agent-vault/context-log.md agent-vault/plan.md
 # Pin the AGENTS.md set (the default discovers every AGENTS.md):
 # agents=discover
-# Point at a path<TAB>reason file of per-file documented overages (create it first):
+# Point at a path<TAB>reason file of per-file documented overages (create it first;
+# excepted files are subtracted from the @-chain total):
 # exceptions=agent-vault/memory-budget.exceptions.tsv
-# Document an intentional always-on @-chain total overage:
-# chain_exception=intentional total overage during migration
 ```
 
 ## `check-context-log-rollover.sh`

--- a/scaffold/root/scripts/check-memory-budget.sh
+++ b/scaffold/root/scripts/check-memory-budget.sh
@@ -28,10 +28,12 @@ set -euo pipefail
 # tolerant of missing files (reported, never fatal). By default it REPORTS and
 # WARNS but exits 0 so it never blocks unrelated commits on a mature repo; pass
 # --strict to fail on a non-excepted over-budget file or bucket. An exceptions
-# file (path<TAB>reason) documents intentional per-file overages; the reserved
-# path "@chain" documents an intentional always-on @-chain total overage (an
-# excepted per-file overage still counts toward the chain total because the file
-# still loads).
+# file (path<TAB>reason) documents intentional per-file overages. The @-chain
+# budget is checked NET of those per-file exceptions, so an approved oversized
+# file does not consume the chain budget while the chain budget keeps governing
+# all non-excepted always-on content. (The legacy reserved "@chain" exception /
+# chain_exception= config is still parsed but DEPRECATED: it no longer
+# suppresses chain overage, because it was unbounded.)
 
 usage() {
   cat <<EOF
@@ -49,7 +51,8 @@ Options:
   --agents "<list>"        Space-separated AGENTS.md files, or "discover" to find
                            every AGENTS.md in the repo (default: discover).
   --exceptions <file>      File of "path<TAB>reason" lines documenting allowed
-                           overages. Use path "@chain" for an @-chain total.
+                           per-file overages (subtracted from the @-chain total).
+                           The reserved "@chain" path is deprecated and ignored.
   --strict                 Exit 1 when a non-excepted file or bucket is over budget.
   --format text|tsv        Output format (default: text).
   -h, --help               Show this help.
@@ -339,6 +342,11 @@ fi
 
 violations=0
 declare -A COUNTED_OVER=()
+# Per-bucket sum of bytes of files that are a documented per-file exception AND
+# over the per-file budget. The @-chain budget is checked NET of these, so an
+# approved oversized file does not consume the chain budget while the chain
+# budget keeps applying to all non-excepted always-on content.
+declare -A BUCKET_EXCEPTED=()
 
 byte_count() {
   wc -c <"$1" | tr -d '[:space:]'
@@ -379,6 +387,7 @@ measure_bucket() {
       if [[ -n "${EXCEPTION_REASON[$rel]:-}" ]]; then
         status="EXCEPT"
         note="over file budget; documented: ${EXCEPTION_REASON[$rel]}"
+        BUCKET_EXCEPTED["$bucket"]=$((${BUCKET_EXCEPTED[$bucket]:-0} + bytes))
       else
         status="OVER"
         note="over file budget ($file_budget bytes)"
@@ -436,26 +445,49 @@ if [[ "$format" == "text" ]]; then
 fi
 measure_bucket "protocol" protocol_total "${protocol_read_files[@]}"
 
-chain_over="false"
-[[ "$claude_total" -gt "$chain_budget" || "$gemini_total" -gt "$chain_budget" ]] && chain_over="true"
+# The @-chain budget is checked NET of documented per-file exceptions: an
+# approved oversized file (an EXCEPT above) is subtracted from its chain total,
+# so the chain budget keeps governing all non-excepted always-on content and a
+# new non-excepted import still fails strict mode.
+claude_excepted="${BUCKET_EXCEPTED[claude]:-0}"
+gemini_excepted="${BUCKET_EXCEPTED[gemini]:-0}"
+claude_net=$((claude_total - claude_excepted))
+gemini_net=$((gemini_total - gemini_excepted))
+
 claude_status="ok"
 gemini_status="ok"
-if [[ "$chain_over" == "true" ]]; then
-  if [[ -n "$chain_exception_reason" ]]; then
-    [[ "$claude_total" -gt "$chain_budget" ]] && claude_status="EXCEPT"
-    [[ "$gemini_total" -gt "$chain_budget" ]] && gemini_status="EXCEPT"
-  else
-    [[ "$claude_total" -gt "$chain_budget" ]] && claude_status="OVER"
-    [[ "$gemini_total" -gt "$chain_budget" ]] && gemini_status="OVER"
-    violations=$((violations + 1))
-  fi
-fi
+chain_over="false"
+[[ "$claude_net" -gt "$chain_budget" ]] && {
+  claude_status="OVER"
+  chain_over="true"
+}
+[[ "$gemini_net" -gt "$chain_budget" ]] && {
+  gemini_status="OVER"
+  chain_over="true"
+}
+[[ "$chain_over" == "true" ]] && violations=$((violations + 1))
+
+# Legacy @chain exception / chain_exception= config is still parsed for backward
+# compatibility (no error) but no longer suppresses chain overage -- the blanket
+# @chain exception was unbounded. Express an approved residual via per-file
+# exceptions (subtracted from the net above) or a configured chain_budget.
+chain_deprecation_note=""
+[[ -n "$chain_exception_reason" ]] && chain_deprecation_note="deprecated: @chain / chain_exception no longer suppresses chain overage; use per-file exceptions"
+
+build_chain_note() {
+  local exc_bytes="$1" net_bytes="$2" note_text=""
+  [[ "$exc_bytes" -gt 0 ]] && note_text="net ${net_bytes} B after ${exc_bytes} B excepted, vs ${chain_budget} budget"
+  [[ -n "$chain_deprecation_note" ]] && note_text="${note_text:+$note_text; }$chain_deprecation_note"
+  printf '%s' "$note_text"
+}
+claude_note="$(build_chain_note "$claude_excepted" "$claude_net")"
+gemini_note="$(build_chain_note "$gemini_excepted" "$gemini_net")"
 
 agents_status="info"
 
 if [[ "$format" == "tsv" ]]; then
-  printf 'TOTAL\tclaude_chain\t%s\t%s\t%s\n' "$claude_status" "$claude_total" "$chain_exception_reason"
-  printf 'TOTAL\tgemini_chain\t%s\t%s\t%s\n' "$gemini_status" "$gemini_total" "$chain_exception_reason"
+  printf 'TOTAL\tclaude_chain\t%s\t%s\t%s\n' "$claude_status" "$claude_total" "$claude_note"
+  printf 'TOTAL\tgemini_chain\t%s\t%s\t%s\n' "$gemini_status" "$gemini_total" "$gemini_note"
   printf 'TOTAL\tagents\t%s\t%s\t\n' "$agents_status" "$agents_total"
   printf 'TOTAL\tprotocol\tinfo\t%s\t\n' "$protocol_total"
 else
@@ -465,7 +497,8 @@ else
   printf '  %-7s %-30s %10s\n' "$gemini_status" "Gemini @-chain total" "$gemini_total"
   printf '  %-7s %-30s %10s\n' "$agents_status" "Codex AGENTS total" "$agents_total"
   printf '  %-7s %-30s %10s\n' "info" "protocol-read total" "$protocol_total"
-  [[ -n "$chain_exception_reason" && "$chain_over" == "true" ]] && echo "  @-chain overage documented: $chain_exception_reason"
+  [[ -n "$claude_note" ]] && echo "  Claude @-chain: $claude_note"
+  [[ -n "$gemini_note" ]] && echo "  Gemini @-chain: $gemini_note"
   echo
   if [[ "$violations" -eq 0 ]]; then
     echo "Within budget (no non-excepted overages)."

--- a/scripts/test-check-memory-budget.sh
+++ b/scripts/test-check-memory-budget.sh
@@ -150,21 +150,43 @@ expect_result 1 "1 non-excepted overage" --repo "$project" --strict
 printf 'agent-vault/project-context.md\tdocumented per-file overage\n' >"$tmp_root/exc-file.tsv"
 expect_result 0 "Within budget" --repo "$project" --strict --exceptions "$tmp_root/exc-file.tsv"
 
-# A chain-only overage (no per-file overage) is a strict violation; an @chain
-# exception clears it, but a per-file exception does not.
+# A chain overage is a strict violation. The @-chain budget is checked NET of
+# per-file exceptions (Option 2), and the legacy @chain exception is DEPRECATED:
+# parsed for backward compatibility but no longer suppressing.
 printf '@chain\tintentional total during a migration\n' >"$tmp_root/exc-chain.tsv"
 expect_result 1 "@-chain total" --repo "$project" --chain-budget 1000 --file-budget 200000 --strict
-expect_result 0 "Within budget" --repo "$project" --chain-budget 1000 --file-budget 200000 --strict --exceptions "$tmp_root/exc-chain.tsv"
+# A legacy @chain exception no longer clears a chain overage (it was unbounded);
+# it reports a deprecation note and still fails strict mode.
+expect_result 1 "deprecated" --repo "$project" --chain-budget 1000 --file-budget 200000 --strict --exceptions "$tmp_root/exc-chain.tsv"
+# A per-file exception for a file that is NOT over the per-file budget is not
+# subtracted, so it does not clear a chain overage either.
 expect_result 1 "@-chain total" --repo "$project" --chain-budget 1000 --file-budget 200000 --strict --exceptions "$tmp_root/exc-file.tsv"
 
-# CRLF exceptions file is tolerated (no-reason @chain line still parses).
+# Net-of-excepted: the inflated project-context.md (~46 KB, over the default
+# per-file budget) is subtracted from each chain when it is a per-file
+# exception, so a chain budget above the ~50 KB remainder passes and one below
+# it fails -- the budget still bites on the non-excepted content.
+printf 'agent-vault/project-context.md\tdocumented oversized file\n' >"$tmp_root/exc-pc.tsv"
+expect_result 0 "Within budget" --repo "$project" --chain-budget 60000 --strict --exceptions "$tmp_root/exc-pc.tsv"
+expect_result 1 "@-chain total" --repo "$project" --chain-budget 40000 --strict --exceptions "$tmp_root/exc-pc.tsv"
+# A legacy @chain row alongside the per-file exception cannot hide that growth
+# (the regression this change exists to prevent).
+printf 'agent-vault/project-context.md\tdoc\n@chain\tlegacy migration suppression\n' >"$tmp_root/exc-pc-legacy.tsv"
+expect_result 1 "deprecated" --repo "$project" --chain-budget 40000 --strict --exceptions "$tmp_root/exc-pc-legacy.tsv"
+
+# CRLF exceptions file is tolerated (parses without a config error). The
+# per-file exception still applies net-of-excepted; the no-reason @chain line
+# parses but is deprecated/non-suppressing.
 printf 'agent-vault/project-context.md\tr\r\n@chain\r\n' >"$tmp_root/exc-crlf.tsv"
-expect_result 0 "Within budget" --repo "$project" --chain-budget 1000 --strict --exceptions "$tmp_root/exc-crlf.tsv"
+expect_result 0 "Within budget" --repo "$project" --chain-budget 60000 --strict --exceptions "$tmp_root/exc-crlf.tsv"
+expect_result 1 "deprecated" --repo "$project" --chain-budget 1000 --strict --exceptions "$tmp_root/exc-crlf.tsv"
 
 # Committed config: budgets, chain_exception, and the override lists all parse.
+# chain_exception= still parses (no error) but is DEPRECATED/non-suppressing, so
+# a chain overage is not cleared by it.
 printf 'file_budget=200000\nchain_budget=1000\nchain_exception=intentional during a migration\n' \
   >"$project/agent-vault/memory-budget.config"
-expect_result 0 "Within budget" --repo "$project" --strict
+expect_result 1 "deprecated" --repo "$project" --strict
 expect_result 0 "Config:" --repo "$project"
 expect_result 1 "over file budget" --repo "$project" --file-budget 500 --strict
 printf 'agent-vault/project-context.md\tdoc\n' >"$project/agent-vault/budget.exceptions.tsv"


### PR DESCRIPTION
## Summary

First implementation slice of #119 (PR-A). Fixes the **unbounded `@chain` memory-budget exception** flagged downstream (crittercam PR #710, Codex GPT-5): in `check-memory-budget.sh`, any non-empty `chain_exception_reason` set both chains to `EXCEPT` and never incremented `violations`, so a documented `@chain` for *today's* residual also silently excepted **all future** chain growth — even `--chain-budget 1` exited 0, and the 120 KB chain budget stopped acting as a pressure gate.

Implements the owner-approved **Option 2 (net-of-excepted)**: the `@`-chain budget is checked **net of documented per-file exceptions**, with the legacy `@chain` / `chain_exception=` deprecated.

## Approach

- **Net-of-excepted.** Each chain accumulates the bytes of its own excepted-and-over-budget files (`BUCKET_EXCEPTED[claude]` / `[gemini]`, per chain — a file shared across both chains is counted in each), subtracts that from the chain total, and compares the **remainder** to `chain_budget`. The 120 KB default keeps governing all non-excepted always-on content, so a new import under the per-file limit still fails `--strict`, and **no `@chain` row is needed**.
- **Deprecation, not removal.** Legacy `@chain` exception rows and `chain_exception=` config are still parsed (no error) but **no longer suppress** chain overage; the report prints a one-line deprecation note. An approved residual is expressed via a per-file exception (subtracted from the net) or a configured `chain_budget`.

## Files
- `scaffold/root/scripts/check-memory-budget.sh` — net-of-excepted comparison, `BUCKET_EXCEPTED` accumulator, deprecation note, header/usage text.
- `scripts/test-check-memory-budget.sh` — regression cases (below).
- `docs/memory-budgets.md` — net-of-excepted explanation; removed the deprecated `chain_exception=` sample.

## Verification
- `scripts/test-check-memory-budget.sh` — **pass.** New/updated cases: net-of-excepted **passes above** the remainder and **fails below** it; a legacy `@chain` alongside a per-file exception **can no longer hide** chain growth (the regression this prevents); the former `@chain` / `chain_exception=` suppression cases now assert the deprecated/non-suppressing behavior.
- `scripts/test-memory-budget-hook.sh` — pass. `scripts/check-style.sh` (shellcheck + shfmt) — pass. `scripts/check-policy-mirrors.sh` — pass. `scripts/test-check-context-log-rollover.sh` — pass.

## Risks / rollback
- Behavior change for any repo that relied on `@chain`/`chain_exception=` to suppress a chain overage — those now report a deprecation note and must re-express the residual as a per-file exception or a `chain_budget`. (Downstream crittercam already moved off `@chain` to a bounded `chain_budget`; it can re-express its residual as the per-file exception once this re-syncs.) Backward compatible at the parse level (no config errors). Revert = revert this commit.

## Docs consistency
- Updated `docs/memory-budgets.md` + the checker header/usage. The policy (`shared-rules.md`) describes the *general* exceptions mechanism and does not promote `@chain`, so no policy/mirror change is needed in this slice.

Part of #119 (PR-A). Owner-approved decisions: **warn-only** enforcement (E) + **Option 2** (net-of-excepted). Not for merge until review + sign-off.
