### PR TITLE
check-context-log-rollover: Layer-2 rollover manifest assertions (#119 PR-B2)

### DIFF
--- a/docs/memory-budgets.md
+++ b/docs/memory-budgets.md
@@ -118,6 +118,7 @@ never edits, moves, or rewrites the log.
 ```bash
 scripts/check-context-log-rollover.sh <context-log-file>
 scripts/check-context-log-rollover.sh <context-log-file> --archive <archive-file>
+scripts/check-context-log-rollover.sh <context-log-file> --archive <archive-file> --manifest <manifest-file>
 ```
 
 Live-file checks:
@@ -137,6 +138,54 @@ labeled superseded, so it cannot read as active.
 The checker keys on the named section headings, so it tolerates mixed entry
 heading styles (`### YYYY-MM-DD ...`, compact `## YYYY-MM-DD ...`, em-dash
 variants) that a real matured log accumulates.
+
+### Layer-2 rollover assertions (`--manifest`)
+
+The structural checks above catch a botched *shape*; they cannot catch a
+rollover whose **durable description is stale**. The failure mode (seen on the
+first real downstream rollover) is *cite-then-mutate*: the archive boundary and
+kept/archived counts are finalized, then the gate-required session entry is
+added — so the live pointer cites a boundary that is no longer the newest entry
+actually moved into the archive. `--manifest` makes that mismatch mechanical by
+comparing the pointer's *claim* to the manifest, and the manifest to archive
+*reality*.
+
+A rollover **manifest** is the parsed source of truth — one record per rollover,
+newest first, at `agent-vault/context/archive/context-log-manifest.md`:
+
+```md
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-2026.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- kept: 5
+- archived: 142
+- anchors: net-of-excepted; rollover policy guard
+```
+
+The live `## Current Snapshot` keeps a human-readable pointer that carries a
+stable link (`rollover_id` + the boundary text) back to that record:
+
+```md
+- Context-log rollover: `2026-05-29-1` — boundary: through PR-A net-of-excepted (recent-window top before rollover)
+```
+
+With `--manifest`, the checker parses the newest manifest record and asserts:
+
+- the live pointer references that record's id and repeats its `boundary`
+  verbatim (a stale or absent pointer is flagged);
+- `newest_archived` / `oldest_archived` are the actual newest / oldest entries
+  in the named archive — entry timestamps normalize to `YYYY-MM-DD HH:MM`, so a
+  shared minute is disambiguated by the full heading (the cite-then-mutate
+  catch);
+- every `anchor` appears in the archive (the moved content really landed);
+- no orphaned top-level `Next Prompt` heading survives in the archive (it must
+  stay nested under its archived entry, never read as an active instruction).
+
+`--manifest` is opt-in and back-compatible: without it, only the structural and
+`--archive` checks run. The archive is located from `--archive` when given, else
+resolved next to the manifest by the record's `archive_file` basename.
 
 ## Compaction conventions
 

--- a/docs/memory-budgets.md
+++ b/docs/memory-budgets.md
@@ -171,21 +171,34 @@ stable link (`rollover_id` + the boundary text) back to that record:
 - Context-log rollover: `2026-05-29-1` — boundary: through PR-A net-of-excepted (recent-window top before rollover)
 ```
 
-With `--manifest`, the checker parses the newest manifest record and asserts:
+All fields are **required** (`kept` / `archived` must be non-negative integers);
+the `*_archived` values are the entry heading text with the leading `#`s
+removed. With `--manifest`, the checker parses the newest manifest record and
+asserts:
 
+- the record carries every field, so it matches the contract PR-B1 will emit
+  (a manifest missing `kept`/`archived`/`anchors` is rejected, not silently
+  accepted);
 - the live pointer references that record's id and repeats its `boundary`
   verbatim (a stale or absent pointer is flagged);
-- `newest_archived` / `oldest_archived` are the actual newest / oldest entries
-  in the named archive — entry timestamps normalize to `YYYY-MM-DD HH:MM`, so a
-  shared minute is disambiguated by the full heading (the cite-then-mutate
-  catch);
-- every `anchor` appears in the archive (the moved content really landed);
+- `newest_archived` / `oldest_archived` **exactly match** the entry the checker
+  independently selects as newest / oldest. Entry timestamps normalize to
+  `YYYY-MM-DD HH:MM`; among entries sharing a minute the archive's newest-at-top
+  order breaks the tie (top-most is newest, bottom-most is oldest), so naming a
+  wrong same-minute heading is caught — not just an older timestamp (the
+  cite-then-mutate catch);
+- every `anchor` appears in the archive (the moved content really landed —
+  prefer distinctive anchor phrases, since the match is a literal substring);
 - no orphaned top-level `Next Prompt` heading survives in the archive (it must
   stay nested under its archived entry, never read as an active instruction).
 
 `--manifest` is opt-in and back-compatible: without it, only the structural and
 `--archive` checks run. The archive is located from `--archive` when given, else
-resolved next to the manifest by the record's `archive_file` basename.
+resolved next to the manifest by the record's `archive_file` basename. The
+counts are validated as integers but **not** reconciled against live/archive
+entry totals — a single archive accumulates many rollovers, so `archived` is a
+per-rollover figure, not the archive's row count; count self-consistency is
+left to the PR-B1 compactor that emits them.
 
 ## Compaction conventions
 

--- a/scaffold/root/scripts/check-context-log-rollover.sh
+++ b/scaffold/root/scripts/check-context-log-rollover.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $0 <context-log-file> [--archive <archive-file>] [--quiet]
+Usage: $0 <context-log-file> [--archive <archive-file>] [--manifest <file>] [--quiet]
 
 Checks (live context log; headings matched outside fenced code blocks):
   - exactly one "## Current Snapshot" (catches a stale duplicate snapshot)
@@ -26,17 +26,41 @@ Checks (live context log; headings matched outside fenced code blocks):
   - if the snapshot declares a latest-handoff pointer, it has an inline value
 Checks (when --archive is given):
   - every archived "## Current Snapshot" is labeled superseded
+Checks (when --manifest is given -- Layer-2 rollover assertions):
+  - the live Current Snapshot's "Context-log rollover" pointer references the
+    newest manifest record's id and repeats its boundary text verbatim
+  - the manifest's newest_archived / oldest_archived headings are the actual
+    newest / oldest entries in the named archive (the cite-then-mutate catch)
+  - every manifest anchor appears in the archive
+  - no orphaned top-level "Next Prompt" heading survives in the archive
 
 Section headings are matched exactly (a distinct heading such as
 "## Current Snapshot Format Notes" is not a duplicate), and CRLF line endings
 are tolerated. Entry heading styles inside "## Entries" are not constrained.
 
+The rollover manifest (parsed source of truth) holds one record per rollover,
+newest first:
+
+  ## rollover: <id>
+  - archive_file: agent-vault/context/archive/context-log-YYYY.md
+  - boundary: <topic / recent-window boundary text>
+  - newest_archived: <full entry heading of the newest archived entry>
+  - oldest_archived: <full entry heading of the oldest archived entry>
+  - kept: <N>
+  - archived: <M>
+  - anchors: <anchor>; <anchor>
+
+The live pointer carries the stable link back to that record:
+
+  - Context-log rollover: \`<id>\` — boundary: <same boundary text>
+
 Exit status: 0 = clean, 1 = violations found, 2 = usage or IO error.
 
 Options:
-  --archive <file>  Also validate an archive file for superseded labeling.
-  --quiet           Print only on failure.
-  -h, --help        Show this help.
+  --archive <file>   Also validate an archive file for superseded labeling.
+  --manifest <file>  Run Layer-2 assertions against a rollover manifest.
+  --quiet            Print only on failure.
+  -h, --help         Show this help.
 EOF
 }
 
@@ -47,6 +71,7 @@ die() {
 
 context_log=""
 archive_file=""
+manifest_file=""
 quiet="false"
 
 while [[ $# -gt 0 ]]; do
@@ -54,6 +79,11 @@ while [[ $# -gt 0 ]]; do
     --archive)
       [[ $# -ge 2 ]] || die "--archive requires a path"
       archive_file="$2"
+      shift 2
+      ;;
+    --manifest)
+      [[ $# -ge 2 ]] || die "--manifest requires a path"
+      manifest_file="$2"
       shift 2
       ;;
     --quiet)
@@ -82,6 +112,9 @@ fi
 [[ -f "$context_log" ]] || die "context log not found: $context_log"
 if [[ -n "$archive_file" && ! -f "$archive_file" ]]; then
   die "archive file not found: $archive_file"
+fi
+if [[ -n "$manifest_file" && ! -f "$manifest_file" ]]; then
+  die "manifest file not found: $manifest_file"
 fi
 
 findings=()
@@ -168,6 +201,143 @@ inspect_archive_superseded() {
   ' "$1"
 }
 
+# --- Layer-2 (rollover manifest) helpers ---------------------------------
+# These run only when --manifest is given. They verify the live pointer's claim
+# against the manifest, and the manifest's claims against archive reality, so a
+# "cite-then-mutate" rollover (numbers finalized before the gate-required entry
+# was added) cannot leave a boundary that is not the archive's actual newest.
+
+# Normalize a value for comparison/lookup: strip markup, collapse whitespace, trim.
+norm() {
+  local s="$1"
+  s="${s//\`/}"
+  s="${s//\*/}"
+  s="$(printf '%s' "$s" | tr -s '[:space:]' ' ')"
+  s="${s# }"
+  s="${s% }"
+  printf '%s' "$s"
+}
+
+# Newest manifest record (first "## rollover:" block) as "key<TAB>value" lines.
+parse_manifest_newest() {
+  awk '
+    function strip(s) {
+      sub(/\r$/, "", s)
+      sub(/^[[:space:]]+/, "", s)
+      sub(/[[:space:]]+$/, "", s)
+      return s
+    }
+    /^##[[:space:]]+rollover:/ {
+      if (seen) exit
+      seen = 1
+      id = $0
+      sub(/^##[[:space:]]+rollover:[[:space:]]*/, "", id)
+      printf "id\t%s\n", strip(id)
+      next
+    }
+    seen && /^##[[:space:]]/ { exit }
+    seen {
+      line = $0
+      sub(/\r$/, "", line)
+      if (match(line, /^[[:space:]]*[-*][[:space:]]*[A-Za-z_]+[[:space:]]*:/)) {
+        sub(/^[[:space:]]*[-*][[:space:]]*/, "", line)
+        ci = index(line, ":")
+        printf "%s\t%s\n", strip(substr(line, 1, ci - 1)), strip(substr(line, ci + 1))
+      }
+    }
+  ' "$1"
+}
+
+# Live-log Current Snapshot rollover pointer as "field/id/boundary" rows.
+parse_live_pointer() {
+  awk '
+    function strip(s) {
+      sub(/\r$/, "", s)
+      sub(/^[[:space:]]+/, "", s)
+      sub(/[[:space:]]+$/, "", s)
+      return s
+    }
+    /^##[[:space:]]+Current Snapshot[[:space:]]*$/ { in_snap = 1; next }
+    in_snap && /^##[[:space:]]/ { exit }
+    in_snap {
+      line = $0
+      sub(/\r$/, "", line)
+      if (tolower(line) ~ /context-log rollover[[:space:]]*:/) {
+        print "field\t1"
+        id = ""
+        if (match(line, /`[^`]+`/)) id = substr(line, RSTART + 1, RLENGTH - 2)
+        printf "id\t%s\n", strip(id)
+        bi = index(tolower(line), "boundary:")
+        if (bi > 0) printf "boundary\t%s\n", strip(substr(line, bi + 9))
+        else print "boundary_missing\t1"
+      }
+    }
+  ' "$1"
+}
+
+# Archive entry-heading extremes + presence of the named newest/oldest headings.
+# An "entry heading" is any heading (outside a fence) whose text starts with a
+# YYYY-MM-DD date; timestamps normalize to "YYYY-MM-DD HH:MM" (00:00 if no time)
+# so lexical compare gives chronological order and a shared minute is unambiguous.
+verify_archive_boundaries() {
+  awk -v newest="$1" -v oldest="$2" '
+    function strip(s) {
+      sub(/\r$/, "", s)
+      sub(/^[[:space:]]+/, "", s)
+      sub(/[[:space:]]+$/, "", s)
+      return s
+    }
+    function entry_ts(text,   d, rest, t) {
+      d = substr(text, 1, 10)
+      rest = substr(text, 11)
+      if (match(rest, /[0-9][0-9]:[0-9][0-9]/)) t = substr(rest, RSTART, 5)
+      else t = "00:00"
+      return d " " t
+    }
+    /^(```|~~~)/ { in_fence = !in_fence; next }
+    {
+      if (in_fence) next
+      line = strip($0)
+      # mawk has no interval expressions ({1,6}); "#+" matches any heading depth.
+      if (line !~ /^#+[[:space:]]/) next
+      sub(/^#+[[:space:]]+/, "", line)
+      if (line !~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) next
+      ts = entry_ts(line)
+      n++
+      if (n == 1 || ts > max_ts) { max_ts = ts; max_h = line }
+      if (n == 1 || ts < min_ts) { min_ts = ts; min_h = line }
+      if (line == newest) { newest_found = 1; newest_ts = ts }
+      if (line == oldest) { oldest_found = 1; oldest_ts = ts }
+    }
+    END {
+      printf "count\t%d\n", n + 0
+      printf "max\t%s\t%s\n", max_ts, max_h
+      printf "min\t%s\t%s\n", min_ts, min_h
+      printf "newest_found\t%d\t%s\n", newest_found + 0, newest_ts
+      printf "oldest_found\t%d\t%s\n", oldest_found + 0, oldest_ts
+    }
+  ' "$3"
+}
+
+# Line numbers of top-level (# or ##) "Next Prompt" headings outside fences --
+# a Next Prompt belongs nested under its entry, never as a standalone section.
+find_orphan_next_prompts() {
+  awk '
+    function strip(s) {
+      sub(/\r$/, "", s)
+      sub(/[[:space:]]+$/, "", s)
+      return s
+    }
+    /^(```|~~~)/ { in_fence = !in_fence; next }
+    {
+      if (in_fence) next
+      line = strip($0)
+      # "##?" = one or two hashes (top-level only); mawk lacks intervals ({1,2}).
+      if (line ~ /^##?[[:space:]]+(Suggested[[:space:]]+)?Next Prompt[[:space:]]*$/) printf "%d ", NR
+    }
+  ' "$1"
+}
+
 mapfile -t scan < <(scan_log "$context_log")
 read -r snap_count usage_count entries_count <<<"${scan[0]:-0 0 0}"
 conflict_lines="${scan[1]:-}"
@@ -190,6 +360,129 @@ if [[ -n "$archive_file" ]]; then
     [[ -n "$row" ]] || continue
     findings+=("archived snapshot is not labeled superseded (archive line ${row%%$'\t'*}) -- archived snapshots must be marked superseded so they cannot read as active")
   done < <(inspect_archive_superseded "$archive_file")
+fi
+
+if [[ -n "$manifest_file" ]]; then
+  declare -A manifest=()
+  manifest_has_record="false"
+  while IFS=$'\t' read -r key value; do
+    [[ -n "$key" ]] || continue
+    manifest["$key"]="$value"
+    manifest_has_record="true"
+  done < <(parse_manifest_newest "$manifest_file")
+
+  pointer_field="false"
+  pointer_id=""
+  pointer_boundary=""
+  pointer_boundary_missing="false"
+  while IFS=$'\t' read -r key value; do
+    case "$key" in
+      field) pointer_field="true" ;;
+      id) pointer_id="$value" ;;
+      boundary) pointer_boundary="$value" ;;
+      boundary_missing) pointer_boundary_missing="true" ;;
+    esac
+  done < <(parse_live_pointer "$context_log")
+
+  if [[ "$manifest_has_record" != "true" ]]; then
+    # An empty manifest with no live pointer is a scaffolded "no rollover yet"
+    # state and is fine; a live pointer with no backing record is not.
+    if [[ "$pointer_field" == "true" ]]; then
+      findings+=("live log declares a rollover pointer but the manifest has no records: $manifest_file")
+    fi
+  else
+    for required in id archive_file boundary newest_archived oldest_archived; do
+      [[ -n "${manifest[$required]:-}" ]] || findings+=("manifest record is missing required field: $required")
+    done
+
+    # Pointer <-> manifest consistency.
+    if [[ "$pointer_field" != "true" ]]; then
+      findings+=("manifest present but live log Current Snapshot declares no \"Context-log rollover\" pointer")
+    else
+      if [[ "$pointer_boundary_missing" == "true" ]]; then
+        findings+=("rollover pointer declares no \"boundary:\" value")
+      fi
+      if [[ -n "${manifest[id]:-}" && "$pointer_id" != "${manifest[id]}" ]]; then
+        findings+=("rollover pointer id \"$pointer_id\" does not match newest manifest record \"${manifest[id]}\"")
+      fi
+      if [[ -n "${manifest[boundary]:-}" && "$pointer_boundary_missing" != "true" ]]; then
+        if [[ "$(norm "$pointer_boundary")" != "$(norm "${manifest[boundary]}")" ]]; then
+          findings+=("rollover pointer boundary does not match the manifest boundary for \"${manifest[id]:-?}\"")
+        fi
+      fi
+    fi
+
+    # Resolve the archive named by the manifest, to verify claims against reality.
+    resolved_archive=""
+    manifest_archive="${manifest[archive_file]:-}"
+    if [[ -n "$archive_file" ]]; then
+      resolved_archive="$archive_file"
+      if [[ -n "$manifest_archive" && "$(basename "$manifest_archive")" != "$(basename "$archive_file")" ]]; then
+        findings+=("manifest archive_file \"$(basename "$manifest_archive")\" does not match --archive \"$(basename "$archive_file")\"")
+      fi
+    elif [[ -n "$manifest_archive" ]]; then
+      candidate="$(dirname "$manifest_file")/$(basename "$manifest_archive")"
+      if [[ -f "$candidate" ]]; then
+        resolved_archive="$candidate"
+      else
+        findings+=("manifest names archive \"$manifest_archive\" but it was not found next to the manifest (pass --archive to locate it)")
+      fi
+    fi
+
+    if [[ -n "$resolved_archive" ]]; then
+      declare -A boundary=()
+      while IFS=$'\t' read -r tag col_a col_b; do
+        case "$tag" in
+          newest_found)
+            boundary[nf]="$col_a"
+            boundary[nts]="$col_b"
+            ;;
+          oldest_found)
+            boundary[of]="$col_a"
+            boundary[ots]="$col_b"
+            ;;
+          max)
+            boundary[max]="$col_a"
+            boundary[maxh]="$col_b"
+            ;;
+          min)
+            boundary[min]="$col_a"
+            boundary[minh]="$col_b"
+            ;;
+        esac
+      done < <(verify_archive_boundaries "${manifest[newest_archived]:-}" "${manifest[oldest_archived]:-}" "$resolved_archive")
+
+      if [[ -n "${manifest[newest_archived]:-}" ]]; then
+        if [[ "${boundary[nf]:-0}" != "1" ]]; then
+          findings+=("manifest newest_archived heading not found in the archive: \"${manifest[newest_archived]}\"")
+        elif [[ -n "${boundary[max]:-}" && "${boundary[nts]:-}" < "${boundary[max]}" ]]; then
+          findings+=("manifest newest_archived is not the newest entry in the archive -- a newer entry is present: \"${boundary[maxh]}\"")
+        fi
+      fi
+      if [[ -n "${manifest[oldest_archived]:-}" ]]; then
+        if [[ "${boundary[of]:-0}" != "1" ]]; then
+          findings+=("manifest oldest_archived heading not found in the archive: \"${manifest[oldest_archived]}\"")
+        elif [[ -n "${boundary[min]:-}" && "${boundary[ots]:-}" > "${boundary[min]}" ]]; then
+          findings+=("manifest oldest_archived is not the oldest entry in the archive -- an older entry is present: \"${boundary[minh]}\"")
+        fi
+      fi
+
+      if [[ -n "${manifest[anchors]:-}" ]]; then
+        IFS=';' read -ra anchor_list <<<"${manifest[anchors]}"
+        for anchor in "${anchor_list[@]}"; do
+          anchor="$(norm "$anchor")"
+          [[ -n "$anchor" ]] || continue
+          grep -Fq -- "$anchor" "$resolved_archive" || findings+=("manifest anchor not found in the archive: \"$anchor\"")
+        done
+      fi
+
+      orphans="$(find_orphan_next_prompts "$resolved_archive")"
+      orphans="${orphans%% }"
+      if [[ -n "${orphans// /}" ]]; then
+        findings+=("orphaned top-level \"Next Prompt\" heading in the archive at line(s): $orphans -- a Next Prompt must stay nested under its archived entry")
+      fi
+    fi
+  fi
 fi
 
 if [[ "${#findings[@]}" -eq 0 ]]; then

--- a/scaffold/root/scripts/check-context-log-rollover.sh
+++ b/scaffold/root/scripts/check-context-log-rollover.sh
@@ -39,16 +39,18 @@ Section headings are matched exactly (a distinct heading such as
 are tolerated. Entry heading styles inside "## Entries" are not constrained.
 
 The rollover manifest (parsed source of truth) holds one record per rollover,
-newest first:
+newest first. All fields are required; the *_archived headings are the entry
+heading text with the leading "#"s removed, and the archive is newest-at-top so
+a same-minute tie resolves to the top-most (newest) / bottom-most (oldest) entry:
 
   ## rollover: <id>
   - archive_file: agent-vault/context/archive/context-log-YYYY.md
   - boundary: <topic / recent-window boundary text>
-  - newest_archived: <full entry heading of the newest archived entry>
-  - oldest_archived: <full entry heading of the oldest archived entry>
+  - newest_archived: <newest archived entry heading, no leading "#">
+  - oldest_archived: <oldest archived entry heading, no leading "#">
   - kept: <N>
   - archived: <M>
-  - anchors: <anchor>; <anchor>
+  - anchors: <anchor>; <anchor>   (each must appear in the archive)
 
 The live pointer carries the stable link back to that record:
 
@@ -304,17 +306,21 @@ verify_archive_boundaries() {
       if (line !~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) next
       ts = entry_ts(line)
       n++
+      # The newest entry is the top-most at the max timestamp and the oldest is
+      # the bottom-most at the min timestamp (archives are newest-at-top). Ties
+      # on a shared minute are broken by position, so max_h/min_h name one
+      # specific heading and a same-minute mismatch is still caught.
       if (n == 1 || ts > max_ts) { max_ts = ts; max_h = line }
-      if (n == 1 || ts < min_ts) { min_ts = ts; min_h = line }
-      if (line == newest) { newest_found = 1; newest_ts = ts }
-      if (line == oldest) { oldest_found = 1; oldest_ts = ts }
+      if (n == 1 || ts <= min_ts) { min_ts = ts; min_h = line }
+      if (line == newest) newest_found = 1
+      if (line == oldest) oldest_found = 1
     }
     END {
       printf "count\t%d\n", n + 0
       printf "max\t%s\t%s\n", max_ts, max_h
       printf "min\t%s\t%s\n", min_ts, min_h
-      printf "newest_found\t%d\t%s\n", newest_found + 0, newest_ts
-      printf "oldest_found\t%d\t%s\n", oldest_found + 0, oldest_ts
+      printf "newest_found\t%d\n", newest_found + 0
+      printf "oldest_found\t%d\n", oldest_found + 0
     }
   ' "$3"
 }
@@ -391,8 +397,13 @@ if [[ -n "$manifest_file" ]]; then
       findings+=("live log declares a rollover pointer but the manifest has no records: $manifest_file")
     fi
   else
-    for required in id archive_file boundary newest_archived oldest_archived; do
+    for required in id archive_file boundary newest_archived oldest_archived kept archived anchors; do
       [[ -n "${manifest[$required]:-}" ]] || findings+=("manifest record is missing required field: $required")
+    done
+    for numeric in kept archived; do
+      value="${manifest[$numeric]:-}"
+      [[ -z "$value" || "$value" =~ ^[0-9]+$ ]] ||
+        findings+=("manifest field $numeric must be a non-negative integer, got: \"$value\"")
     done
 
     # Pointer <-> manifest consistency.
@@ -433,37 +444,28 @@ if [[ -n "$manifest_file" ]]; then
       declare -A boundary=()
       while IFS=$'\t' read -r tag col_a col_b; do
         case "$tag" in
-          newest_found)
-            boundary[nf]="$col_a"
-            boundary[nts]="$col_b"
-            ;;
-          oldest_found)
-            boundary[of]="$col_a"
-            boundary[ots]="$col_b"
-            ;;
-          max)
-            boundary[max]="$col_a"
-            boundary[maxh]="$col_b"
-            ;;
-          min)
-            boundary[min]="$col_a"
-            boundary[minh]="$col_b"
-            ;;
+          newest_found) boundary[nf]="$col_a" ;;
+          oldest_found) boundary[of]="$col_a" ;;
+          max) boundary[maxh]="$col_b" ;;
+          min) boundary[minh]="$col_b" ;;
         esac
       done < <(verify_archive_boundaries "${manifest[newest_archived]:-}" "${manifest[oldest_archived]:-}" "$resolved_archive")
 
+      # Require an exact heading match against the entry the checker independently
+      # selects as newest/oldest (max/min timestamp, ties broken by position), so
+      # naming a wrong same-minute heading is caught, not just an older timestamp.
       if [[ -n "${manifest[newest_archived]:-}" ]]; then
         if [[ "${boundary[nf]:-0}" != "1" ]]; then
           findings+=("manifest newest_archived heading not found in the archive: \"${manifest[newest_archived]}\"")
-        elif [[ -n "${boundary[max]:-}" && "${boundary[nts]:-}" < "${boundary[max]}" ]]; then
-          findings+=("manifest newest_archived is not the newest entry in the archive -- a newer entry is present: \"${boundary[maxh]}\"")
+        elif [[ "${manifest[newest_archived]}" != "${boundary[maxh]:-}" ]]; then
+          findings+=("manifest newest_archived is not the archive's newest entry -- the newest archived entry is: \"${boundary[maxh]}\"")
         fi
       fi
       if [[ -n "${manifest[oldest_archived]:-}" ]]; then
         if [[ "${boundary[of]:-0}" != "1" ]]; then
           findings+=("manifest oldest_archived heading not found in the archive: \"${manifest[oldest_archived]}\"")
-        elif [[ -n "${boundary[min]:-}" && "${boundary[ots]:-}" > "${boundary[min]}" ]]; then
-          findings+=("manifest oldest_archived is not the oldest entry in the archive -- an older entry is present: \"${boundary[minh]}\"")
+        elif [[ "${manifest[oldest_archived]}" != "${boundary[minh]:-}" ]]; then
+          findings+=("manifest oldest_archived is not the archive's oldest entry -- the oldest archived entry is: \"${boundary[minh]}\"")
         fi
       fi
 

--- a/scripts/test-check-context-log-rollover.sh
+++ b/scripts/test-check-context-log-rollover.sh
@@ -392,4 +392,280 @@ set -e
   exit 1
 }
 
+# --- Layer-2: rollover manifest assertions (--manifest) ------------------
+
+# A good archive: superseded snapshot + dated entries, newest first. The newest
+# entry carries a *nested* "#### Next Prompt" (legal -- must NOT be flagged).
+cat >"$tmp_root/context-log-2026.md" <<'EOF'
+# Context Log Archive (2026)
+
+## Current Snapshot — SUPERSEDED (archived 2026-05-30; see live log for current state)
+- Active branch: `old-branch`
+
+### 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
+#### State
+- Implemented net-of-excepted chain budget.
+#### Next Prompt
+- Continue with PR-B2 (rollover Layer-2).
+
+### 2026-03-15 09:00 local - codex - mid-window work
+- Body.
+
+### 2026-01-04 09:00 local - bootstrap - initial project setup
+- Body.
+EOF
+
+# A live log whose Current Snapshot carries a rollover pointer back to the manifest.
+cat >"$tmp_root/good-rollover-live.md" <<'EOF'
+# Context Log
+
+## Usage Rules
+- Newest entry at top.
+
+## Current Snapshot
+- Active branch: `main`
+- Context-log rollover: `2026-05-29-1` — boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- Last updated: 2026-05-30
+
+## Entries
+
+### 2026-05-30 09:00 local - claude - recent work
+- Body.
+EOF
+
+# The matching manifest: newest record first, claims consistent with the archive.
+cat >"$tmp_root/manifest-good.md" <<'EOF'
+# Context Log Rollover Manifest
+
+<!-- One record per rollover, newest first. Validated by check-context-log-rollover.sh --manifest. -->
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-2026.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- kept: 5
+- archived: 3
+- anchors: net-of-excepted; initial project setup
+EOF
+
+# Healthy rollover: pointer, manifest, and archive all agree.
+expect_result 0 "passed" "$tmp_root/good-rollover-live.md" \
+  --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-good.md"
+
+# The nested "#### Next Prompt" in the archive is legal and not flagged as orphan.
+out_healthy="$("$checker" "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-good.md" 2>&1)"
+[[ "$out_healthy" != *"orphaned"* ]] || {
+  echo "FAIL: nested Next Prompt should not be flagged as orphan; got: $out_healthy" >&2
+  exit 1
+}
+
+# Manifest resolves its own archive (no --archive) when co-located by basename.
+mkdir -p "$tmp_root/co"
+cp "$tmp_root/context-log-2026.md" "$tmp_root/co/context-log-2026.md"
+cp "$tmp_root/manifest-good.md" "$tmp_root/co/manifest.md"
+expect_result 0 "passed" "$tmp_root/good-rollover-live.md" --manifest "$tmp_root/co/manifest.md"
+
+# Scaffolded manifest with no records + a live log with no pointer = "no rollover
+# yet" and passes; structural checks still run.
+cat >"$tmp_root/manifest-empty.md" <<'EOF'
+# Context Log Rollover Manifest
+
+(No rollovers yet.)
+EOF
+expect_result 0 "passed" "$tmp_root/no-handoff-live.md" --manifest "$tmp_root/manifest-empty.md"
+
+# A live pointer with no backing manifest record is a defect.
+expect_result 1 "manifest has no records" "$tmp_root/good-rollover-live.md" --manifest "$tmp_root/manifest-empty.md"
+
+# Manifest present but the live Current Snapshot has no rollover pointer.
+expect_result 1 'declares no "Context-log rollover" pointer' \
+  "$tmp_root/no-handoff-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-good.md"
+
+# Pointer id does not match the newest manifest record.
+cat >"$tmp_root/bad-id-live.md" <<'EOF'
+# Context Log
+
+## Usage Rules
+- x
+
+## Current Snapshot
+- Context-log rollover: `2099-12-31-9` — boundary: through PR-A net-of-excepted (recent-window top before rollover)
+
+## Entries
+
+### 2026-05-30 09:00 local - a - b
+- c
+EOF
+expect_result 1 "does not match newest manifest record" \
+  "$tmp_root/bad-id-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-good.md"
+
+# Pointer boundary text does not match the manifest boundary (the cite-then-mutate
+# drift, caught at the pointer layer).
+cat >"$tmp_root/bad-boundary-live.md" <<'EOF'
+# Context Log
+
+## Usage Rules
+- x
+
+## Current Snapshot
+- Context-log rollover: `2026-05-29-1` — boundary: an entirely different boundary description
+
+## Entries
+
+### 2026-05-30 09:00 local - a - b
+- c
+EOF
+expect_result 1 "boundary does not match the manifest boundary" \
+  "$tmp_root/bad-boundary-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-good.md"
+
+# A rollover pointer with no "boundary:" value is flagged.
+cat >"$tmp_root/no-boundary-live.md" <<'EOF'
+# Context Log
+
+## Usage Rules
+- x
+
+## Current Snapshot
+- Context-log rollover: `2026-05-29-1`
+
+## Entries
+
+### 2026-05-30 09:00 local - a - b
+- c
+EOF
+expect_result 1 'declares no "boundary:" value' \
+  "$tmp_root/no-boundary-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-good.md"
+
+# newest_archived is NOT the actual newest entry -- the core cite-then-mutate
+# mechanical catch. Same id/boundary as the good pointer to isolate this finding.
+cat >"$tmp_root/manifest-stale-newest.md" <<'EOF'
+# Context Log Rollover Manifest
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-2026.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-03-15 09:00 local - codex - mid-window work
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- anchors: net-of-excepted
+EOF
+expect_result 1 "is not the newest entry in the archive" \
+  "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-stale-newest.md"
+
+# newest_archived names a heading absent from the archive.
+cat >"$tmp_root/manifest-missing-newest.md" <<'EOF'
+# Context Log Rollover Manifest
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-2026.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-05-29 17:00 local - claude - a heading that was never archived
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+EOF
+expect_result 1 "newest_archived heading not found in the archive" \
+  "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-missing-newest.md"
+
+# oldest_archived names a heading absent from the archive.
+cat >"$tmp_root/manifest-missing-oldest.md" <<'EOF'
+# Context Log Rollover Manifest
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-2026.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
+- oldest_archived: 2025-01-01 00:00 local - nobody - never archived
+EOF
+expect_result 1 "oldest_archived heading not found in the archive" \
+  "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-missing-oldest.md"
+
+# A representative anchor is absent from the archive.
+cat >"$tmp_root/manifest-bad-anchor.md" <<'EOF'
+# Context Log Rollover Manifest
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-2026.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- anchors: net-of-excepted; this-anchor-string-is-nowhere-in-the-archive
+EOF
+expect_result 1 "anchor not found in the archive" \
+  "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-bad-anchor.md"
+
+# A required manifest field is missing.
+cat >"$tmp_root/manifest-missing-field.md" <<'EOF'
+# Context Log Rollover Manifest
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-2026.md
+- newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+EOF
+expect_result 1 "missing required field: boundary" \
+  "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-missing-field.md"
+
+# An orphaned top-level "Next Prompt" survives in the archive.
+cat >"$tmp_root/context-log-orphan.md" <<'EOF'
+# Context Log Archive (2026)
+
+## Current Snapshot — SUPERSEDED (archived 2026-05-30)
+- Active branch: `old-branch`
+
+### 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
+- Body.
+
+### 2026-01-04 09:00 local - bootstrap - initial project setup
+- Body.
+
+## Suggested Next Prompt
+- Continue the work.
+EOF
+cat >"$tmp_root/manifest-orphan.md" <<'EOF'
+# Context Log Rollover Manifest
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-orphan.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+EOF
+expect_result 1 'orphaned top-level "Next Prompt"' \
+  "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-orphan.md" --manifest "$tmp_root/manifest-orphan.md"
+
+# Manifest archive_file basename disagrees with an explicit --archive.
+cat >"$tmp_root/manifest-altarchive.md" <<'EOF'
+# Context Log Rollover Manifest
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-2025.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+EOF
+expect_result 1 "does not match --archive" \
+  "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-altarchive.md"
+
+# Manifest names an archive that cannot be located next to it (no --archive).
+cat >"$tmp_root/manifest-lonely.md" <<'EOF'
+# Context Log Rollover Manifest
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-missing.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+EOF
+expect_result 1 "was not found next to the manifest" \
+  "$tmp_root/good-rollover-live.md" --manifest "$tmp_root/manifest-lonely.md"
+
+# A missing manifest file is an IO error.
+expect_result 2 "manifest file not found" \
+  "$tmp_root/good-rollover-live.md" --manifest "$tmp_root/does-not-exist-manifest.md"
+
+# CRLF manifest + live log still validate (CR tolerated on both sides).
+sed 's/$/\r/' "$tmp_root/good-rollover-live.md" >"$tmp_root/good-rollover-crlf-live.md"
+sed 's/$/\r/' "$tmp_root/manifest-good.md" >"$tmp_root/manifest-good-crlf.md"
+expect_result 0 "passed" "$tmp_root/good-rollover-crlf-live.md" \
+  --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-good-crlf.md"
+
 echo "context-log rollover checker regression checks passed."

--- a/scripts/test-check-context-log-rollover.sh
+++ b/scripts/test-check-context-log-rollover.sh
@@ -547,10 +547,63 @@ cat >"$tmp_root/manifest-stale-newest.md" <<'EOF'
 - boundary: through PR-A net-of-excepted (recent-window top before rollover)
 - newest_archived: 2026-03-15 09:00 local - codex - mid-window work
 - oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
-- anchors: net-of-excepted
+- kept: 5
+- archived: 3
+- anchors: net-of-excepted; initial project setup
 EOF
-expect_result 1 "is not the newest entry in the archive" \
+expect_result 1 "is not the archive's newest entry" \
   "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-stale-newest.md"
+
+# Two archived entries share a minute; newest_archived names the lower/stale one.
+# Same timestamp as the actual newest, so a timestamp-only check would miss it --
+# the full-heading comparison must still catch it (the same-minute ambiguity this
+# slice exists to close).
+cat >"$tmp_root/context-log-tie.md" <<'EOF'
+# Context Log Archive (2026)
+
+## Current Snapshot — SUPERSEDED (archived 2026-05-30)
+- Active branch: `old-branch`
+
+### 2026-05-29 17:00 local - claude - newer same-minute entry
+- Body.
+
+### 2026-05-29 17:00 local - claude - older same-minute entry
+- Body.
+
+### 2026-01-04 09:00 local - bootstrap - initial project setup
+- Body.
+EOF
+cat >"$tmp_root/manifest-tie-stale.md" <<'EOF'
+# Context Log Rollover Manifest
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-tie.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-05-29 17:00 local - claude - older same-minute entry
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- kept: 5
+- archived: 3
+- anchors: same-minute entry; initial project setup
+EOF
+expect_result 1 "is not the archive's newest entry" \
+  "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-tie.md" --manifest "$tmp_root/manifest-tie-stale.md"
+
+# Same tie archive, but newest_archived names the top-most (newest) same-minute
+# heading -- this is the correct boundary and passes.
+cat >"$tmp_root/manifest-tie-good.md" <<'EOF'
+# Context Log Rollover Manifest
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-tie.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-05-29 17:00 local - claude - newer same-minute entry
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- kept: 5
+- archived: 3
+- anchors: same-minute entry; initial project setup
+EOF
+expect_result 0 "passed" \
+  "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-tie.md" --manifest "$tmp_root/manifest-tie-good.md"
 
 # newest_archived names a heading absent from the archive.
 cat >"$tmp_root/manifest-missing-newest.md" <<'EOF'
@@ -561,6 +614,9 @@ cat >"$tmp_root/manifest-missing-newest.md" <<'EOF'
 - boundary: through PR-A net-of-excepted (recent-window top before rollover)
 - newest_archived: 2026-05-29 17:00 local - claude - a heading that was never archived
 - oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- kept: 5
+- archived: 3
+- anchors: net-of-excepted; initial project setup
 EOF
 expect_result 1 "newest_archived heading not found in the archive" \
   "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-missing-newest.md"
@@ -574,6 +630,9 @@ cat >"$tmp_root/manifest-missing-oldest.md" <<'EOF'
 - boundary: through PR-A net-of-excepted (recent-window top before rollover)
 - newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
 - oldest_archived: 2025-01-01 00:00 local - nobody - never archived
+- kept: 5
+- archived: 3
+- anchors: net-of-excepted; initial project setup
 EOF
 expect_result 1 "oldest_archived heading not found in the archive" \
   "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-missing-oldest.md"
@@ -587,12 +646,14 @@ cat >"$tmp_root/manifest-bad-anchor.md" <<'EOF'
 - boundary: through PR-A net-of-excepted (recent-window top before rollover)
 - newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
 - oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- kept: 5
+- archived: 3
 - anchors: net-of-excepted; this-anchor-string-is-nowhere-in-the-archive
 EOF
 expect_result 1 "anchor not found in the archive" \
   "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-bad-anchor.md"
 
-# A required manifest field is missing.
+# A required schema field is missing (boundary), with the rest of the record valid.
 cat >"$tmp_root/manifest-missing-field.md" <<'EOF'
 # Context Log Rollover Manifest
 
@@ -600,9 +661,56 @@ cat >"$tmp_root/manifest-missing-field.md" <<'EOF'
 - archive_file: agent-vault/context/archive/context-log-2026.md
 - newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
 - oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- kept: 5
+- archived: 3
+- anchors: net-of-excepted; initial project setup
 EOF
 expect_result 1 "missing required field: boundary" \
   "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-missing-field.md"
+
+# The pinned schema is enforced: omitting kept / archived / anchors fails, and a
+# non-numeric count fails.
+cat >"$tmp_root/manifest-no-counts.md" <<'EOF'
+# Context Log Rollover Manifest
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-2026.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- anchors: net-of-excepted; initial project setup
+EOF
+expect_result 1 "missing required field: kept" \
+  "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-no-counts.md"
+
+cat >"$tmp_root/manifest-no-anchors.md" <<'EOF'
+# Context Log Rollover Manifest
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-2026.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- kept: 5
+- archived: 3
+EOF
+expect_result 1 "missing required field: anchors" \
+  "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-no-anchors.md"
+
+cat >"$tmp_root/manifest-bad-count.md" <<'EOF'
+# Context Log Rollover Manifest
+
+## rollover: 2026-05-29-1
+- archive_file: agent-vault/context/archive/context-log-2026.md
+- boundary: through PR-A net-of-excepted (recent-window top before rollover)
+- newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
+- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- kept: five
+- archived: 3
+- anchors: net-of-excepted; initial project setup
+EOF
+expect_result 1 "kept must be a non-negative integer" \
+  "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-bad-count.md"
 
 # An orphaned top-level "Next Prompt" survives in the archive.
 cat >"$tmp_root/context-log-orphan.md" <<'EOF'
@@ -628,6 +736,9 @@ cat >"$tmp_root/manifest-orphan.md" <<'EOF'
 - boundary: through PR-A net-of-excepted (recent-window top before rollover)
 - newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
 - oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- kept: 5
+- archived: 3
+- anchors: net-of-excepted; initial project setup
 EOF
 expect_result 1 'orphaned top-level "Next Prompt"' \
   "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-orphan.md" --manifest "$tmp_root/manifest-orphan.md"
@@ -641,6 +752,9 @@ cat >"$tmp_root/manifest-altarchive.md" <<'EOF'
 - boundary: through PR-A net-of-excepted (recent-window top before rollover)
 - newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
 - oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- kept: 5
+- archived: 3
+- anchors: net-of-excepted; initial project setup
 EOF
 expect_result 1 "does not match --archive" \
   "$tmp_root/good-rollover-live.md" --archive "$tmp_root/context-log-2026.md" --manifest "$tmp_root/manifest-altarchive.md"
@@ -654,6 +768,9 @@ cat >"$tmp_root/manifest-lonely.md" <<'EOF'
 - boundary: through PR-A net-of-excepted (recent-window top before rollover)
 - newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
 - oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
+- kept: 5
+- archived: 3
+- anchors: net-of-excepted; initial project setup
 EOF
 expect_result 1 "was not found next to the manifest" \
   "$tmp_root/good-rollover-live.md" --manifest "$tmp_root/manifest-lonely.md"


### PR DESCRIPTION
## Summary

Third implementation slice of #119 (**PR-B2**). The merged **PR-B3 #121** added a *prose* policy guard against the "cite-then-mutate" rollover drift; this slice adds the **mechanical** Layer-2 backstop. It pins the rollover **manifest + live-pointer schema** and adds an opt-in `--manifest` mode to `check-context-log-rollover.sh` that compares the pointer's *claim* to the manifest and the manifest to archive *reality*.

**Cite-then-mutate** (seen on the first real downstream rollover): the durable description (archive boundary, kept/archived counts) is finalized, then the gate-required session entry is added — so the pointer cites a boundary that is no longer the newest entry actually moved into the archive. Structure-only checks can't see this; a checker that compares pointer claims to archive reality can.

## Schema (the contract — please review)

A structured **manifest sidecar** is the parsed source of truth — one record per rollover, newest first, at `agent-vault/context/archive/context-log-manifest.md`:

```md
## rollover: 2026-05-29-1
- archive_file: agent-vault/context/archive/context-log-2026.md
- boundary: through PR-A net-of-excepted (recent-window top before rollover)
- newest_archived: 2026-05-29 17:00 local - claude - PR-A net-of-excepted shipped
- oldest_archived: 2026-01-04 09:00 local - bootstrap - initial project setup
- kept: 5
- archived: 142
- anchors: net-of-excepted; rollover policy guard
```

The live `## Current Snapshot` keeps a **human-readable** pointer carrying a stable link (`rollover_id` + the boundary text) back to that record:

```md
- Context-log rollover: `2026-05-29-1` — boundary: through PR-A net-of-excepted (recent-window top before rollover)
```

This matches the schema settled in the issue thread (manifest sidecar as source of truth; human-readable pointer with a machine-checkable `rollover_id` link; boundary matched by string equality, not prose parsing). Concrete choices made here and open to review: the manifest **file location**, the `## rollover: <id>` + `- key: value` **record syntax**, and the explicit `boundary:` keyword in the pointer. PR-B1 (the compactor) will *produce* this schema, so it is the load-bearing contract.

## Assertions (with `--manifest`)

1. The live pointer references the newest record's `id` and **repeats its `boundary` verbatim** (a stale, mismatched, or absent pointer is flagged).
2. `newest_archived` / `oldest_archived` are the **actual newest / oldest entries** in the named archive — entry timestamps normalize to `YYYY-MM-DD HH:MM`, so a shared minute is disambiguated by the full heading. **This is the cite-then-mutate catch.**
3. Every manifest **anchor** appears in the archive (the moved content really landed).
4. No orphaned top-level `Next Prompt` heading survives in the archive (it must stay nested under its archived entry).

`--manifest` is **opt-in and back-compatible**: without it, only the existing structural and `--archive` checks run. The archive is located from `--archive` when given, else resolved next to the manifest by the record's `archive_file` basename.

## Files

- `scaffold/root/scripts/check-context-log-rollover.sh` — `--manifest` option; manifest/pointer parsers; archive boundary/anchor/orphan assertions; expanded `--help` documenting the schema. Regex kept **mawk-safe** (no `{n,m}` interval expressions — `#+` and `##?` instead).
- `scripts/test-check-context-log-rollover.sh` — Layer-2 fixtures and cases.
- `docs/memory-budgets.md` — new "Layer-2 rollover assertions (`--manifest`)" subsection.

No new managed artifact, so no propagation wiring is needed — this edits the already-seeded/synced checker in place.

## Verification

- `scripts/test-check-context-log-rollover.sh` — **pass.** New cases: healthy rollover (pointer+manifest+archive agree); pointer id mismatch; pointer boundary mismatch; missing/empty pointer; **newest_archived is not the actual newest** (the core catch); newest/oldest heading absent; missing anchor; missing required field; orphaned top-level `Next Prompt` (and a *nested* `#### Next Prompt` asserted **not** flagged); archive-basename mismatch; archive un-locatable; missing manifest (exit 2); co-located archive resolution; CRLF manifest + log.
- `scripts/check-style.sh` (bash syntax + ShellCheck `--severity=warning` + `shfmt -i 2 -ci`) — **pass.**
- Back-compat smoke: the real `scaffold/agent-vault/context-log.md` still passes with no `--manifest`.
- Full `scaffold-regression-checks` set run locally — all pass **except** `test-session-metadata-hook`, which **fails identically on clean `main`** (pre-existing, environment-specific; `scaffold-regression-checks` is green in CI on `main`). Not touched by this PR.

## Risks / rollback

- Behavior is **additive and opt-in**; existing callers (including the pre-commit warning) are unaffected until they pass `--manifest`. Revert = revert this commit.
- The schema is a forward contract for PR-B1; if reviewers want a different manifest location/syntax, better to settle here before the compactor produces it.

## Docs consistency

- `docs/memory-budgets.md` updated (the rollover section is the checker reference). No `docs/design.md` in this repo. Policy (`shared-rules.md`) already references "the archive's own frontmatter/manifest" (added in PR-B3), so no policy/mirror change is needed.

Part of #119 (PR-B2). Not for merge until review + sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
