### PR TITLE
pre-commit: non-blocking context-log rollover warning (D2); defer hook closure optimization (D1) (#119 PR-D)

### DIFF
--- a/docs/memory-budgets.md
+++ b/docs/memory-budgets.md
@@ -312,10 +312,20 @@ When a file is over budget:
 `check-context-log-rollover.sh`, `check-lessons-archive.sh`) and the
 `compact-context-log.sh` compactor into a generated project's `scripts/`, and
 `update-project.sh` keeps them in sync (they carry an `agent-vault-managed`
-marker, like the worktree helpers). The scaffolded pre-commit hook runs
-`scripts/check-memory-budget.sh` as a **non-blocking** warning when memory files
-are staged -- it surfaces any over-budget bucket/file but never blocks a commit
-(silence it with `AGENT_VAULT_SKIP_MEMORY_BUDGET=1`).
+marker, like the worktree helpers). The scaffolded pre-commit hook runs two
+**non-blocking** warnings against the **staged** content (never blocking a
+commit):
+
+- `scripts/check-memory-budget.sh` when memory files are staged -- surfaces any
+  over-budget bucket/file (silence with `AGENT_VAULT_SKIP_MEMORY_BUDGET=1`);
+- `scripts/check-context-log-rollover.sh` when `agent-vault/context-log.md` is
+  staged -- surfaces a stale duplicate `## Current Snapshot`, leftover conflict
+  markers, or an empty handoff pointer (silence with
+  `AGENT_VAULT_SKIP_ROLLOVER_CHECK=1`).
+
+The budget warning materializes the staged index to measure the full `@`-chain;
+the rollover warning reads only the single staged `context-log.md` blob via
+`git show`.
 
 In the agent-vault template repo itself the checkers live at
 `scaffold/root/scripts/`; the commands above assume a generated project where

--- a/scaffold/agent-vault/_assets/hooks/pre-commit
+++ b/scaffold/agent-vault/_assets/hooks/pre-commit
@@ -63,7 +63,48 @@ warn_memory_budget() {
   return 0
 }
 
+# Non-blocking context-log rollover warning: when agent-vault/context-log.md is
+# staged and the rollover checker is installed, surface structural rollover
+# problems in the STAGED content -- a stale duplicate "## Current Snapshot",
+# leftover Git conflict markers, an empty handoff pointer -- but never block the
+# commit. Runs even when the metadata gate is skipped; silence with
+# AGENT_VAULT_SKIP_ROLLOVER_CHECK=1.
+warn_context_log_rollover() {
+  if [[ "${AGENT_VAULT_SKIP_ROLLOVER_CHECK:-}" == "1" ]]; then
+    return 0
+  fi
+  [[ -x scripts/check-context-log-rollover.sh ]] || return 0
+
+  local staged="false" file_path
+  for file_path in "${all_staged_files[@]}"; do
+    if [[ "$file_path" == "agent-vault/context-log.md" ]]; then
+      staged="true"
+      break
+    fi
+  done
+  [[ "$staged" == "true" ]] || return 0
+
+  # Validate the staged blob (the index, not the working tree).
+  local tmp_file rollover_output
+  tmp_file="$(mktemp "${TMPDIR:-/tmp}/agent-vault-rollover-staged.XXXXXX")" || return 0
+  if ! git show ":agent-vault/context-log.md" >"$tmp_file" 2>/dev/null; then
+    rm -f "$tmp_file"
+    return 0
+  fi
+  if rollover_output="$(scripts/check-context-log-rollover.sh "$tmp_file" --quiet 2>&1)"; then
+    rm -f "$tmp_file"
+    return 0
+  fi
+  rm -f "$tmp_file"
+
+  echo "agent-vault context-log rollover warning (non-blocking; staged agent-vault/context-log.md; set AGENT_VAULT_SKIP_ROLLOVER_CHECK=1 to silence):" >&2
+  printf '%s\n' "$rollover_output" | grep '^- ' >&2 || true
+  echo "Run scripts/check-context-log-rollover.sh agent-vault/context-log.md for the full report." >&2
+  return 0
+}
+
 warn_memory_budget
+warn_context_log_rollover
 
 if [[ "${AGENT_VAULT_SKIP_METADATA_GATE:-}" == "1" ]]; then
   exit 0

--- a/scaffold/agent-vault/_assets/hooks/pre-commit
+++ b/scaffold/agent-vault/_assets/hooks/pre-commit
@@ -99,7 +99,10 @@ warn_context_log_rollover() {
 
   echo "agent-vault context-log rollover warning (non-blocking; staged agent-vault/context-log.md; set AGENT_VAULT_SKIP_ROLLOVER_CHECK=1 to silence):" >&2
   printf '%s\n' "$rollover_output" | grep '^- ' >&2 || true
-  echo "Run scripts/check-context-log-rollover.sh agent-vault/context-log.md for the full report." >&2
+  # This reflects the STAGED blob, which can differ from the working tree on a
+  # partial-stage; point at the staged content, not the working-tree file.
+  echo "The full report is on the STAGED content; inspect exactly what is staged with:" >&2
+  echo "  git show :agent-vault/context-log.md >\"\${TMPDIR:-/tmp}\"/staged-context-log.md && scripts/check-context-log-rollover.sh \"\${TMPDIR:-/tmp}\"/staged-context-log.md" >&2
   return 0
 }
 

--- a/scripts/test-memory-budget-hook.sh
+++ b/scripts/test-memory-budget-hook.sh
@@ -122,12 +122,17 @@ AGENT_VAULT_SKIP_METADATA_GATE=1 commit_capture "$p" git commit -qm c7
 [[ "$HOOK_RC" -eq 0 ]] || fail "clean context-log commit was blocked (rc=$HOOK_RC)" "$HOOK_STDERR"
 [[ "$HOOK_STDERR" != *"context-log rollover warning"* ]] || fail "rollover warning on a clean context-log" "$HOOK_STDERR"
 
-# Case 8a: STAGED duplicate snapshot but working tree reverted clean -> warns on STAGED.
+# Case 8a: STAGED duplicate snapshot but working tree reverted clean -> warns on
+# STAGED, and the follow-up guidance points at the staged content (not the clean
+# working-tree file, which would falsely report no issue here).
 p="$(fresh_project case8a)"
 stage_dup_snapshot "$p"
 git -C "$p" show HEAD:agent-vault/context-log.md >"$p/agent-vault/context-log.md"
 AGENT_VAULT_SKIP_METADATA_GATE=1 commit_capture "$p" git commit -qm c8a
 [[ "$HOOK_STDERR" == *"context-log rollover warning"* ]] || fail "did not warn on staged duplicate (working tree clean)" "$HOOK_STDERR"
+[[ "$HOOK_STDERR" == *"STAGED content"* ]] || fail "8a: guidance does not clarify the warning is about staged content" "$HOOK_STDERR"
+[[ "$HOOK_STDERR" == *"git show :agent-vault/context-log.md"* ]] || fail "8a: guidance offers no staged-content inspection path" "$HOOK_STDERR"
+[[ "$HOOK_STDERR" != *"check-context-log-rollover.sh agent-vault/context-log.md for the full report"* ]] || fail "8a: guidance points at the working-tree file for the full report" "$HOOK_STDERR"
 
 # Case 8b: STAGED clean but working tree has a duplicate (unstaged) -> no warning.
 p="$(fresh_project case8b)"
@@ -136,5 +141,13 @@ git -C "$p" add agent-vault/context-log.md
 printf '\n## Current Snapshot\n- Active branch: `old-stale-branch`\n' >>"$p/agent-vault/context-log.md"
 AGENT_VAULT_SKIP_METADATA_GATE=1 commit_capture "$p" git commit -qm c8b
 [[ "$HOOK_STDERR" != *"context-log rollover warning"* ]] || fail "warned on unstaged working-tree duplicate snapshot" "$HOOK_STDERR"
+
+# Case 9: context-log.md staged for deletion -> no staged blob -> silent no-op
+# (the warning never fires and never blocks the commit).
+p="$(fresh_project case9)"
+git -C "$p" rm -q agent-vault/context-log.md
+AGENT_VAULT_SKIP_METADATA_GATE=1 commit_capture "$p" git commit -qm c9
+[[ "$HOOK_RC" -eq 0 ]] || fail "staged deletion was blocked by the rollover warning (rc=$HOOK_RC)" "$HOOK_STDERR"
+[[ "$HOOK_STDERR" != *"context-log rollover warning"* ]] || fail "warned on a staged deletion (no staged blob)" "$HOOK_STDERR"
 
 echo "memory budget + context-log rollover pre-commit hook regression checks passed."

--- a/scripts/test-memory-budget-hook.sh
+++ b/scripts/test-memory-budget-hook.sh
@@ -90,4 +90,51 @@ oversize >>"$p/agent-vault/project-context.md"
 AGENT_VAULT_SKIP_METADATA_GATE=1 commit_capture "$p" git commit -qm c4b
 [[ "$HOOK_STDERR" != *"memory-budget warning"* ]] || fail "warned on unstaged working-tree content" "$HOOK_STDERR"
 
-echo "memory budget pre-commit hook regression checks passed."
+# --- context-log rollover warning (D2) -----------------------------------
+
+# Stage agent-vault/context-log.md with a stale duplicate "## Current Snapshot".
+stage_dup_snapshot() {
+  printf '\n## Current Snapshot\n- Active branch: `old-stale-branch`\n' >>"$1/agent-vault/context-log.md"
+  git -C "$1" add agent-vault/context-log.md
+}
+
+# Case 5: a staged context-log with a duplicate snapshot prints a non-blocking
+# rollover warning naming the finding; the commit still succeeds.
+p="$(fresh_project case5)"
+stage_dup_snapshot "$p"
+AGENT_VAULT_SKIP_METADATA_GATE=1 commit_capture "$p" git commit -qm c5
+[[ "$HOOK_RC" -eq 0 ]] || fail "rollover-warning commit was blocked (rc=$HOOK_RC)" "$HOOK_STDERR"
+[[ "$HOOK_STDERR" == *"context-log rollover warning"* ]] || fail "no rollover warning on duplicate snapshot" "$HOOK_STDERR"
+[[ "$HOOK_STDERR" == *'duplicate "## Current Snapshot"'* ]] || fail "rollover warning omitted the finding" "$HOOK_STDERR"
+
+# Case 6: AGENT_VAULT_SKIP_ROLLOVER_CHECK=1 silences the rollover warning.
+p="$(fresh_project case6)"
+stage_dup_snapshot "$p"
+AGENT_VAULT_SKIP_METADATA_GATE=1 AGENT_VAULT_SKIP_ROLLOVER_CHECK=1 commit_capture "$p" git commit -qm c6
+[[ "$HOOK_RC" -eq 0 ]] || fail "silenced rollover commit was blocked (rc=$HOOK_RC)" "$HOOK_STDERR"
+[[ "$HOOK_STDERR" != *"context-log rollover warning"* ]] || fail "AGENT_VAULT_SKIP_ROLLOVER_CHECK did not silence" "$HOOK_STDERR"
+
+# Case 7: a clean staged context-log change prints no rollover warning.
+p="$(fresh_project case7)"
+printf -- '- extra clean note\n' >>"$p/agent-vault/context-log.md"
+git -C "$p" add agent-vault/context-log.md
+AGENT_VAULT_SKIP_METADATA_GATE=1 commit_capture "$p" git commit -qm c7
+[[ "$HOOK_RC" -eq 0 ]] || fail "clean context-log commit was blocked (rc=$HOOK_RC)" "$HOOK_STDERR"
+[[ "$HOOK_STDERR" != *"context-log rollover warning"* ]] || fail "rollover warning on a clean context-log" "$HOOK_STDERR"
+
+# Case 8a: STAGED duplicate snapshot but working tree reverted clean -> warns on STAGED.
+p="$(fresh_project case8a)"
+stage_dup_snapshot "$p"
+git -C "$p" show HEAD:agent-vault/context-log.md >"$p/agent-vault/context-log.md"
+AGENT_VAULT_SKIP_METADATA_GATE=1 commit_capture "$p" git commit -qm c8a
+[[ "$HOOK_STDERR" == *"context-log rollover warning"* ]] || fail "did not warn on staged duplicate (working tree clean)" "$HOOK_STDERR"
+
+# Case 8b: STAGED clean but working tree has a duplicate (unstaged) -> no warning.
+p="$(fresh_project case8b)"
+printf -- '- extra clean note\n' >>"$p/agent-vault/context-log.md"
+git -C "$p" add agent-vault/context-log.md
+printf '\n## Current Snapshot\n- Active branch: `old-stale-branch`\n' >>"$p/agent-vault/context-log.md"
+AGENT_VAULT_SKIP_METADATA_GATE=1 commit_capture "$p" git commit -qm c8b
+[[ "$HOOK_STDERR" != *"context-log rollover warning"* ]] || fail "warned on unstaged working-tree duplicate snapshot" "$HOOK_STDERR"
+
+echo "memory budget + context-log rollover pre-commit hook regression checks passed."


### PR DESCRIPTION
## Summary

Sixth and final slice of #119 (**PR-D**) — the pre-commit hook work. It ships **D2** (the non-blocking context-log rollover warning) and makes an explicit, plan-sanctioned **NO-GO on D1** (the hook closure optimization). This closes out #119.

## D2 — context-log rollover warning

Adds `warn_context_log_rollover()` to `scaffold/agent-vault/_assets/hooks/pre-commit`, mirroring the existing `warn_memory_budget()`. When `agent-vault/context-log.md` is staged and `check-context-log-rollover.sh` is installed, it validates the **staged blob** (`git show ":agent-vault/context-log.md"`, not the working tree) and surfaces structural rollover problems — a stale duplicate `## Current Snapshot`, leftover Git conflict markers, an empty handoff pointer — as a **non-blocking** warning. It honors the settled warn-only enforcement and is silenced with `AGENT_VAULT_SKIP_ROLLOVER_CHECK=1`.

Reading a single staged blob via `git show` is simpler and cheaper than the budget warning's full-index materialization — it touches only the one file.

The hook is an **existing managed asset** (synced by `update-project.sh`, seeded by `new-project.sh`), so editing its content propagates with no new wiring; verified `new-project` seeds the updated hook.

## D1 — NO-GO (deferred), with rationale

D1 was to replace `git checkout-index -a` (`pre-commit:47`, ~25 MiB/commit on large repos) with a materializer for only the `@`-chain closure via a new `scripts/lib/chain-closure.sh`.

The `@`-import resolver (`check-memory-budget.sh:249` `resolve_at_imports`) reads file **contents** from the filesystem to follow imports. A correctness-preserving D1 must compute that closure from **staged blobs** (`git show ":path"`) behind a shared dual-backend lib, then `checkout-index` only those pathspecs. Per the #119 plan's explicit go/no-go:

- the current `checkout-index -a` is **I/O-heavy but correct**;
- D1 is a **performance-only** change whose failure mode is *silently measuring the wrong content* (a working-tree regression Codex specifically warned against);
- that risk isn't worth it for a **non-blocking advisory** warning.

So `checkout-index -a` stays and only D2 ships — the outcome the plan explicitly permits ("if even that is too much complexity, leave `checkout-index -a` in place and ship only D2"). Deferred as a standalone follow-up if the per-commit I/O is ever felt on a large repo.

## Files

- `scaffold/agent-vault/_assets/hooks/pre-commit` — `warn_context_log_rollover()` + its call.
- `scripts/test-memory-budget-hook.sh` — D2 regression cases.
- `docs/memory-budgets.md` — Installation section documents both staged-content hook warnings.

## Verification

- `scripts/test-memory-budget-hook.sh` — **pass**. New cases: duplicate-snapshot warns and the commit still succeeds (rc 0); `AGENT_VAULT_SKIP_ROLLOVER_CHECK=1` silences it; a clean context-log does not warn; and **two staged-index-truth cases** — staged duplicate + reverted-clean working tree **warns**, staged clean + dirty (unstaged) working tree **does not** — proving it reads the index, not the working tree.
- `new-project.sh` seeds the updated hook (D2 present); the hook is in `update-project.sh`'s managed sync set, so existing projects get it too.
- `scripts/check-style.sh` (bash + ShellCheck `--severity=warning` + `shfmt -i 2 -ci`) and `scripts/check-policy-mirrors.sh` — pass.
- Full `scaffold-regression-checks` set run locally — all pass **except** `test-session-metadata-hook`, which **fails identically on clean `main`** (a pre-existing `update-project.sh` reporting issue, environment-specific; green in CI). Confirmed the failure reason is unchanged and unrelated to the hook edit.

## Risks / rollback

- Additive, non-blocking, and behind a skip var; no change to the metadata gate or any blocking behavior. Revert = revert this commit.
- No new managed helper and no closure refactor (D1 deferred), so no new propagation surface or staged-index-resolver risk.

## Docs consistency

- `docs/memory-budgets.md` Installation updated. No `docs/design.md` in this repo. No policy/mirror change (the hook is an asset, not a policy file); `check-policy-mirrors.sh` passes.

Part of #119 (PR-D) — the final slice. Not for merge until review + sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
