### PR TITLE
compact-context-log: fix headerless-archive entry duplication

### DIFF
--- a/.github/workflows/scaffold-regression-checks.yml
+++ b/.github/workflows/scaffold-regression-checks.yml
@@ -28,6 +28,8 @@ on:
       - "scripts/parse-claude-memory-trace.py"
       - "scripts/test-check-memory-budget.sh"
       - "scripts/test-check-context-log-rollover.sh"
+      - "scripts/test-check-lessons-archive.sh"
+      - "scripts/test-compact-context-log.sh"
       - ".github/workflows/scaffold-regression-checks.yml"
   push:
     branches:
@@ -58,6 +60,8 @@ on:
       - "scripts/parse-claude-memory-trace.py"
       - "scripts/test-check-memory-budget.sh"
       - "scripts/test-check-context-log-rollover.sh"
+      - "scripts/test-check-lessons-archive.sh"
+      - "scripts/test-compact-context-log.sh"
       - ".github/workflows/scaffold-regression-checks.yml"
   workflow_dispatch:
 
@@ -97,3 +101,7 @@ jobs:
         run: bash scripts/test-check-memory-budget.sh
       - name: Verify context-log rollover checker
         run: bash scripts/test-check-context-log-rollover.sh
+      - name: Verify lessons-archive checker
+        run: bash scripts/test-check-lessons-archive.sh
+      - name: Verify context-log compactor
+        run: bash scripts/test-compact-context-log.sh

--- a/scaffold/root/scripts/compact-context-log.sh
+++ b/scaffold/root/scripts/compact-context-log.sh
@@ -464,7 +464,14 @@ new_record="$scratch/record"
 if [[ -f "$manifest_file" ]]; then
   first_record="$(grep -n '^## rollover:' "$manifest_file" | head -n1 | cut -d: -f1 || true)"
   if [[ -n "$first_record" ]]; then
-    sed -n "1,$((first_record - 1))p" "$manifest_file" | strip_trailing_blanks - >"$scratch/man_header"
+    if [[ "$first_record" -gt 1 ]]; then
+      sed -n "1,$((first_record - 1))p" "$manifest_file" | strip_trailing_blanks - >"$scratch/man_header"
+    else
+      # Headerless manifest: the first record is on line 1, so there is no header to
+      # slice. sed "1,0p" would wrongly emit line 1 on GNU sed and re-append it from
+      # man_existing, duplicating the first record. Seed the standard manifest header.
+      printf '# Context Log Rollover Manifest\n\n<!-- One record per rollover, newest first. Maintained by compact-context-log.sh; validated by check-context-log-rollover.sh --manifest. -->\n' >"$scratch/man_header"
+    fi
     sed -n "${first_record},\$p" "$manifest_file" >"$scratch/man_existing"
   else
     strip_trailing_blanks "$manifest_file" >"$scratch/man_header"

--- a/scaffold/root/scripts/compact-context-log.sh
+++ b/scaffold/root/scripts/compact-context-log.sh
@@ -377,7 +377,14 @@ archived_count=$((total_entries - keep))
 if [[ -f "$archive_file" ]]; then
   first_existing="$(first_entry_line "$archive_file")"
   if [[ -n "$first_existing" ]]; then
-    sed -n "1,$((first_existing - 1))p" "$archive_file" | strip_trailing_blanks - >"$scratch/arch_header"
+    if [[ "$first_existing" -gt 1 ]]; then
+      sed -n "1,$((first_existing - 1))p" "$archive_file" | strip_trailing_blanks - >"$scratch/arch_header"
+    else
+      # Headerless archive: the first entry is on line 1, so there is no header to
+      # slice. sed "1,0p" would wrongly emit line 1 on GNU sed and then re-append it
+      # from arch_existing, duplicating and reordering the first archived entry.
+      printf '# Context Log Archive\n' >"$scratch/arch_header"
+    fi
     sed -n "${first_existing},\$p" "$archive_file" >"$scratch/arch_existing"
   else
     strip_trailing_blanks "$archive_file" >"$scratch/arch_header"

--- a/scripts/test-compact-context-log.sh
+++ b/scripts/test-compact-context-log.sh
@@ -554,4 +554,47 @@ pass=$((pass + 1))
 pass=$((pass + 1))
 assert_not_exists "$d/archive/manifest.md" "guard dry-run: no manifest written"
 
+# 13. Headerless existing archive (first dated entry on line 1): no duplication or
+# reorder. first_entry_line returns 1, so the header slice must NOT be sed "1,0p"
+# (GNU sed emits line 1, which would then be re-appended from arch_existing).
+d="$tmp_root/headerless"
+mkdir -p "$d/archive"
+make_log "$d/log.md"
+cat >"$d/archive/context-log-2026.md" <<'EOF'
+### 2026-05-01 09:00 local - claude - pre-existing archived entry
+- Body.
+EOF
+run_compact "$d/log.md" --keep 1 --archive "$d/archive/context-log-2026.md" \
+  --manifest "$d/archive/manifest.md" --require-top-entry "rollover session"
+assert_rc 0 "$COMPACT_RC" "headerless archive compacts"
+"$checker" "$d/log.md" --archive "$d/archive/context-log-2026.md" \
+  --manifest "$d/archive/manifest.md" >/dev/null || fail "headerless: checker rejected result"
+pass=$((pass + 1))
+# The pre-existing entry must appear exactly once (the bug duplicated it).
+[[ "$(grep -c 'pre-existing archived entry' "$d/archive/context-log-2026.md")" -eq 1 ]] ||
+  fail "headerless: pre-existing entry must not be duplicated"
+pass=$((pass + 1))
+# Order: the newly moved batch (newer) sits above the older pre-existing entry.
+moved_ln="$(grep -n 'feature work' "$d/archive/context-log-2026.md" | head -n1 | cut -d: -f1)"
+old_ln="$(grep -n 'pre-existing archived entry' "$d/archive/context-log-2026.md" | head -n1 | cut -d: -f1)"
+[[ -n "$moved_ln" && -n "$old_ln" && "$moved_ln" -lt "$old_ln" ]] ||
+  fail "headerless: moved batch must be newest-first above the pre-existing entry"
+pass=$((pass + 1))
+
+# 14. Header present but no dated entries yet (first_entry_line empty -> else
+# branch): the batch is appended after the existing header, no duplication.
+d="$tmp_root/header-no-entries"
+mkdir -p "$d/archive"
+make_log "$d/log.md"
+printf '# Context Log Archive\n\nSome prose, no dated entries yet.\n' >"$d/archive/context-log-2026.md"
+run_compact "$d/log.md" --keep 1 --archive "$d/archive/context-log-2026.md" \
+  --manifest "$d/archive/manifest.md" --require-top-entry "rollover session"
+assert_rc 0 "$COMPACT_RC" "header-only archive compacts"
+"$checker" "$d/log.md" --archive "$d/archive/context-log-2026.md" \
+  --manifest "$d/archive/manifest.md" >/dev/null || fail "header-only: checker rejected result"
+pass=$((pass + 1))
+[[ "$(grep -c 'Some prose, no dated entries yet' "$d/archive/context-log-2026.md")" -eq 1 ]] ||
+  fail "header-only: existing header prose must not be duplicated"
+pass=$((pass + 1))
+
 echo "compact-context-log compactor regression checks passed ($pass assertions)."

--- a/scripts/test-compact-context-log.sh
+++ b/scripts/test-compact-context-log.sh
@@ -597,4 +597,36 @@ pass=$((pass + 1))
   fail "header-only: existing header prose must not be duplicated"
 pass=$((pass + 1))
 
+# 15. Headerless manifest (first record on line 1): parity with the archive fix —
+# the same sed "1,0p" class must not duplicate/mangle the existing manifest record.
+d="$tmp_root/headerless-manifest"
+mkdir -p "$d/archive"
+make_log "$d/log.md"
+cat >"$d/archive/manifest.md" <<'EOF'
+## rollover: 2026-05-01-1
+- archive_file: x/context-log-2026.md
+- boundary: through old
+- newest_archived: 2026-05-01 09:00 local - x - older
+- oldest_archived: 2026-05-01 09:00 local - x - older
+- kept: 1
+- archived: 1
+- anchors: older; older
+EOF
+run_compact "$d/log.md" --keep 1 --archive "$d/archive/context-log-2026.md" \
+  --manifest "$d/archive/manifest.md" --rollover-id 2026-06-02-1 --require-top-entry "rollover session"
+assert_rc 0 "$COMPACT_RC" "headerless manifest compacts"
+"$checker" "$d/log.md" --archive "$d/archive/context-log-2026.md" \
+  --manifest "$d/archive/manifest.md" >/dev/null || fail "headerless manifest: checker rejected result"
+pass=$((pass + 1))
+# The pre-existing record must appear exactly once (the bug duplicated/mangled it).
+[[ "$(grep -c '^## rollover: 2026-05-01-1' "$d/archive/manifest.md")" -eq 1 ]] ||
+  fail "headerless manifest: existing record must not be duplicated"
+pass=$((pass + 1))
+# The newest record is the freshly written one, above the pre-existing record.
+new_ln="$(grep -n '^## rollover: 2026-06-02-1' "$d/archive/manifest.md" | head -n1 | cut -d: -f1)"
+old_ln="$(grep -n '^## rollover: 2026-05-01-1' "$d/archive/manifest.md" | head -n1 | cut -d: -f1)"
+[[ -n "$new_ln" && -n "$old_ln" && "$new_ln" -lt "$old_ln" ]] ||
+  fail "headerless manifest: new record must be newest-first above the pre-existing record"
+pass=$((pass + 1))
+
 echo "compact-context-log compactor regression checks passed ($pass assertions)."


### PR DESCRIPTION
> 🤖 **Post by Claude Opus 4.8 (1M context)** · via Claude Code

## Problem
`scaffold/root/scripts/compact-context-log.sh` duplicates and reorders the first entry when growing an archive whose first dated entry is on **line 1** (a headerless archive). `first_entry_line` returns `1`, so the header slice `sed -n "1,$((first_existing-1))p"` becomes `sed -n "1,0p"` — which on GNU sed still emits line 1. That first entry is captured as "header", then re-appended from `arch_existing` (`sed -n "1,\$p"`), so the result is: the older existing entry, the moved batch, then a **duplicate** of the older entry.

Reproduced with `--keep 1` against a temp headerless archive: rc 0 and self-validation passed, but the archive contained the pre-existing entry twice, in the wrong order.

## Fix
Special-case `first_existing == 1`: seed the header (`# Context Log Archive`, matching the create path) instead of the buggy `1,0p` slice. The existing entries then come only from `arch_existing`, so there is no duplication and the order stays newest-first. Header-bearing archives and the create path are unchanged.

## Files
- `scaffold/root/scripts/compact-context-log.sh`: guard the header slice on `first_existing > 1`; seed the header when the archive is headerless.
- `scripts/test-compact-context-log.sh`: regression fixtures — a headerless archive (pre-existing entry appears exactly once, newest-first order, checker passes) and a header-only archive (existing prose not duplicated). 105 assertions.

## Verification
- `bash scripts/test-compact-context-log.sh` → 105 assertions pass.
- `bash scripts/check-style.sh` → clean (shfmt `-i 2 -ci` + shellcheck).
- RED confirmed against the pre-fix script (pre-existing entry duplicated, reordered); GREEN after.

## Notes
Surfaced in a downstream review of the synced compactor. The downstream project's own archive is header-bearing, so it never triggered this — but the script advertises growing existing archives, and a headerless one is a valid shape. No `design.md` / `README` impact.
