### PR TITLE
Add review-only external-feedback memory exception and existing-repo migration

### DIFF
--- a/.github/workflows/scaffold-regression-checks.yml
+++ b/.github/workflows/scaffold-regression-checks.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/test-gitignore-management.sh"
       - "scripts/test-coding-standards-sync.sh"
       - "scripts/test-decision-template-sync.sh"
+      - "scripts/test-context-log-policy-sync.sh"
       - "scripts/test-session-metadata-hook.sh"
       - "scripts/test-memory-budget-hook.sh"
       - "scripts/test-main-push-gate.sh"
@@ -46,6 +47,7 @@ on:
       - "scripts/test-gitignore-management.sh"
       - "scripts/test-coding-standards-sync.sh"
       - "scripts/test-decision-template-sync.sh"
+      - "scripts/test-context-log-policy-sync.sh"
       - "scripts/test-session-metadata-hook.sh"
       - "scripts/test-memory-budget-hook.sh"
       - "scripts/test-main-push-gate.sh"
@@ -77,6 +79,8 @@ jobs:
         run: bash scripts/test-coding-standards-sync.sh
       - name: Verify policy template sync behavior
         run: bash scripts/test-decision-template-sync.sh
+      - name: Verify context-log policy sync and migration
+        run: bash scripts/test-context-log-policy-sync.sh
       - name: Verify session metadata hook behavior
         run: bash scripts/test-session-metadata-hook.sh
       - name: Verify memory budget pre-commit hook behavior

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,6 +343,14 @@ If the platform or API blocks the intended formal review state (e.g., permission
 ## Responding to Review Feedback
 When asked to address review feedback in a PR comment, use a complete, itemized response.
 
+Transient external review feedback is not project memory: the issue/PR/doc thread
+is the durable record until feedback converges. Follow the review-only exception
+under `Session End - Required` in the shared agent rules for when a converged
+outcome should be recorded (summarize the outcome and link the thread; do not copy
+comment text into always-on memory). Example: feedback posted on a GitHub issue
+asking for plan review with no owner decision yet needs no context-log entry; the
+thread is the record until something converges.
+
 ### Feedback Retrieval Checklist
 Before claiming that all PR feedback was reviewed or addressed, inspect every
 available feedback surface:

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Run the scaffold regression scripts locally when changing bootstrap, sync, or tr
 - `bash scripts/test-gitignore-management.sh`
 - `bash scripts/test-coding-standards-sync.sh`
 - `bash scripts/test-decision-template-sync.sh`
+- `bash scripts/test-context-log-policy-sync.sh`
 - `bash scripts/test-session-metadata-hook.sh`
 - `bash scripts/test-main-push-gate.sh`
 - `bash scripts/test-session-start-load-contract.sh`
@@ -162,6 +163,7 @@ CI also runs these checks via `.github/workflows/scaffold-regression-checks.yml`
   - `<repo>/agent-vault/context/handoffs/README.md`
   - `<repo>/agent-vault/decisions/README.md`
   - `<repo>/agent-vault/daily/README.md`
+  - `<repo>/agent-vault/Templates/Context Log.md`
   - `<repo>/agent-vault/Templates/Decision Record.md`
 - Root wrappers (managed only when the root file has the `agent-vault-managed` marker):
   - `<repo>/AGENTS.md`
@@ -191,7 +193,7 @@ If an existing root worktree helper script does not have the managed marker,
 
 Template refresh is opt-in:
 - `./scripts/update-project.sh <repo-path> --sync-templates` updates `agent-vault/Templates/` from the scaffold and backs up replaced files under `agent-vault/context/updates/<timestamp>/`.
-- Without `--sync-templates`, project-local template customizations are left alone except for policy-critical templates that are always managed (`agent-vault/Templates/Decision Record.md`).
+- Without `--sync-templates`, project-local template customizations are left alone except for policy-critical templates that are always managed (`agent-vault/Templates/Context Log.md`, `agent-vault/Templates/Decision Record.md`).
 
 Coding standards refresh is also opt-in:
 - `./scripts/update-project.sh <repo-path> --sync-coding-standards` replaces `agent-vault/coding-standards.md` with the scaffold version and backs up the previous file under `agent-vault/context/updates/<timestamp>/`.
@@ -239,6 +241,7 @@ The tracked `pre-commit` hook enforces the baseline session artifacts and valida
 
 That shortcut allows recording history after PR merges while keeping source code, config, scripts, root docs, policy files, templates, hook assets, and durable project docs such as `agent-vault/README.md`, `plan.md`, `coding-standards.md`, `project-context.md`, `project-commands.md`, and `handoff.md` on the PR path.
 When syncing older generated repos, `update-project.sh` now auto-migrates recognized legacy `agent-vault/context-log.md` layouts into the validator-compatible top-level `## Current Snapshot` / `## Entries` shape before syncing the stricter hook. If the layout is not recognized, the script leaves the file unchanged and prints a manual-remediation warning instead of guessing.
+It also inserts the review-only / external-feedback usage rule (issue #129) into an existing runtime `agent-vault/context-log.md` when its active `## Usage Rules` section predates the rule: the rule line is copied verbatim from the scaffold context log, the previous file is backed up under `agent-vault/context/updates/<timestamp>/`, and the insert is idempotent. When no active `## Usage Rules` section sits above `## Current Snapshot`, the script prints a skip notice instead of editing archived or unrecognized content.
 
 Both scripts also ensure root `.gitignore` includes managed local-only ignore entries (added only when missing):
 - `.obsidian/workspace.json`

--- a/scaffold/agent-vault/AGENTS.md
+++ b/scaffold/agent-vault/AGENTS.md
@@ -185,6 +185,7 @@ Use the canonical ordering for each artifact type below instead of guessing base
 - In committed memory artifacts, prefer repo-relative paths and portable command examples such as `agent-vault/...`, `docs/...`, `./scripts/...`, or `<repo-root>/...`. Machine-specific absolute paths such as `/Users/...`, `/home/...`, or `C:\...` are acceptable only when the local path itself is relevant debugging or environment context.
 - Create or update `agent-vault/daily/YYYY-MM-DD.md` on the first substantive work session of each local day. Reuse the same file for later sessions that day. Skip daily notes for trivial one-off requests.
 - Add a design-log note for every substantive work session.
+- Review-only external-feedback sessions that produced no converged project state follow the `Session End - Required` exception: skip the daily and design-log notes and say so in your final summary.
 - When a durable decision is made about architecture, workflow, API shape, data model, deployment, or tool policy, create a decision record in `agent-vault/decisions/` and add it to `agent-vault/decision-log.md`.
 - When handing off or pausing with meaningful unfinished work, create a handoff note in `agent-vault/context/handoffs/`, include a `Suggested Next Prompt`, and reference that note from `agent-vault/context-log.md`.
 - Use the standalone handoff prompt template only when a human explicitly asks for a copy-paste prompt. Otherwise keep the prompt inside the handoff note and the latest `context-log.md` entry.
@@ -256,6 +257,14 @@ When performing research or writing research-oriented documentation (design-log 
 - If handing off, add a note in `agent-vault/context/handoffs/`.
 - If the user corrected a mistake during this session, add an entry to `agent-vault/lessons.md` describing the mistake pattern and a preventive rule.
 - Before creating a commit for substantive work, make sure today's daily note, context log, and any new design-log entry do not leave same-session publication mechanics (`git commit`, `git push`, PR creation) in `Carry Forward`, `Next`, or equivalent future-tense text unless those actions will truly remain unfinished after the session.
+- Review-only / external-feedback exception: when the session's only durable output was feedback posted to an external thread (a GitHub issue, PR review, or doc comment thread) and nothing converged into project state, skip the project-memory writes above and say so in your final summary instead of writing empty artifacts. The external thread is the durable record of non-converged feedback; do not duplicate it into always-on memory. If the feedback surfaced a material trade-off awaiting an owner decision, the skip still applies unless active local work depends on the outcome — then add a one-line `agent-vault/open-questions.md` entry linking the thread. Example: plan-review feedback posted on a GitHub issue with no owner decision yet needs no context-log entry; the issue thread is the record until something converges.
+- For external feedback, write to project memory only when it converges into a durable state, then summarize the final outcome and link the external thread rather than copying comment text. Durable states:
+  - an accepted decision or owner-approved plan,
+  - an implemented or merged change,
+  - an unresolved blocker,
+  - a handoff with concrete remaining work,
+  - a reusable lesson or process rule, or
+  - an external-thread pointer that future agents need to resume active work or understand current project state.
 - Treat these updates as a commit gate for substantive work, not as optional cleanup after the code is already done.
 
 ## Direct Push to Main
@@ -267,7 +276,7 @@ When performing research or writing research-oriented documentation (design-log 
 ## Completion Verification - MUST follow before marking any task done
 Before reporting a task as finished:
 1. Run the Verification Loop appropriate to the repo and change scope.
-2. List the `agent-vault` artifacts created or updated this session, or explicitly state why no metadata update was required (for example, a trivial one-off request).
+2. List the `agent-vault` artifacts created or updated this session, or explicitly state why no metadata update was required (for example, a trivial one-off request, or a review-only session whose feedback lives in an external thread and did not converge into project state).
 3. Ask yourself: "Would a senior engineer approve this?" If not, fix it first.
 4. If any Verification Loop step was unavailable or could not run, explicitly state what was checked and what remains unverified.
 
@@ -312,7 +321,7 @@ Before considering any change complete and before running git commit:
   - `agent-vault/context/handoffs/` when handing off unfinished work
   - `agent-vault/lessons.md` when a corrected mistake should become a durable prevention rule
 - If the repo enables the tracked hooks under `agent-vault/_assets/hooks/`, keep them enabled via `git config core.hooksPath agent-vault/_assets/hooks`.
-- If a change is truly trivial and should not update project memory, make that an explicit decision and say so in your final summary instead of silently skipping the metadata step.
+- If a change is truly trivial and should not update project memory — including when the only staged change is trivial and the session's remaining output was non-converged external review feedback — make that an explicit decision and say so in your final summary instead of silently skipping the metadata step.
 
 ## Additional Guardrails
 - Prefer explicit diffs over whole-file rewrites when updating docs.

--- a/scaffold/agent-vault/Templates/Context Log.md
+++ b/scaffold/agent-vault/Templates/Context Log.md
@@ -15,6 +15,7 @@ last_updated:
 - Pair each major update with a design-log entry.
 - Add a handoff note when transferring work between agents/sessions.
 - Reference the active handoff note or decision record when one changes current work.
+- Review-only / external-feedback exception: if the session only posted external review feedback that did not converge into project state, the `Session End - Required` exception in `agent-vault/shared-rules.md` applies — record a one-line thread pointer only if future agents need it; otherwise skip the entry.
 
 ## Current Snapshot
 - Project:

--- a/scaffold/agent-vault/_assets/hooks/README.md
+++ b/scaffold/agent-vault/_assets/hooks/README.md
@@ -76,6 +76,11 @@ AGENT_VAULT_SKIP_METADATA_GATE=1 git commit ...
 
 Use that escape hatch sparingly and explain the skip in the task summary or commit context.
 
+The same explicit-bypass expectation applies when a review-only session (external
+feedback only, nothing converged into project state) needs to commit a genuinely
+trivial change: use the bypass and state the review-only skip in the task summary,
+per the `Session End - Required` exception in `agent-vault/shared-rules.md`.
+
 The non-blocking memory-budget warning is independent of the metadata gate.
 Silence it on its own (it never blocks a commit either way):
 

--- a/scaffold/agent-vault/context-log.md
+++ b/scaffold/agent-vault/context-log.md
@@ -15,6 +15,7 @@ last_updated: __DATE__
 - Pair each major update with a design-log entry.
 - Add a handoff note when switching agents or ending a session.
 - Reference the active handoff note or decision record when one changes current work.
+- Review-only / external-feedback exception: if the session only posted external review feedback that did not converge into project state, the `Session End - Required` exception in `agent-vault/shared-rules.md` applies — record a one-line thread pointer only if future agents need it; otherwise skip the entry.
 
 ## Current Snapshot
 - Project: __PROJECT_NAME__

--- a/scaffold/agent-vault/daily/README.md
+++ b/scaffold/agent-vault/daily/README.md
@@ -6,6 +6,7 @@ Daily notes are supplemental. Durable decisions, open questions, and handoffs mu
 
 Read today's note first if it exists.
 Create or update `YYYY-MM-DD.md` on the first substantive work session of the day.
+Skip the daily note when the session only posted external review feedback that did not converge into project state (see the `Session End - Required` exception in `agent-vault/shared-rules.md`).
 Keep same-day content chronological: append new work log entries or added session sections at the bottom rather than inserting newer work at the top.
 
 Suggested filename:

--- a/scaffold/agent-vault/handoff.md
+++ b/scaffold/agent-vault/handoff.md
@@ -8,6 +8,7 @@ Use this when switching between agents or pausing with meaningful unfinished wor
 - Add a design-log entry in `agent-vault/design-log/`.
 - If the session was substantive, update today's note in `agent-vault/daily/`.
 - If a durable decision was made, update `agent-vault/decision-log.md` and `agent-vault/decisions/`.
+- Review-only / external-feedback exception: if the session only posted external review feedback that did not converge into project state, the `Session End - Required` exception in `agent-vault/shared-rules.md` applies — record a one-line thread pointer only if future agents need it; otherwise skip these artifacts.
 
 ## Suggested Next Prompt
 ```
@@ -37,4 +38,5 @@ Before finishing:
 - Add a design-log entry in agent-vault/design-log/.
 - If you made a durable decision, update decision-log and `agent-vault/decisions/`.
 - If handing off again, add a note in agent-vault/context/handoffs/ with a Suggested Next Prompt.
+- If this session only posted external review feedback that did not converge into project state, apply the `Session End - Required` exception in agent-vault/shared-rules.md instead of writing these artifacts, and say so in your final summary.
 ```

--- a/scaffold/agent-vault/review-policy.md
+++ b/scaffold/agent-vault/review-policy.md
@@ -307,6 +307,14 @@ If the platform or API blocks the intended formal review state (e.g., permission
 ## Responding to Review Feedback
 When asked to address review feedback in a PR comment, use a complete, itemized response.
 
+Transient external review feedback is not project memory: the issue/PR/doc thread
+is the durable record until feedback converges. Follow the review-only exception
+under `Session End - Required` in the shared agent rules for when a converged
+outcome should be recorded (summarize the outcome and link the thread; do not copy
+comment text into always-on memory). Example: feedback posted on a GitHub issue
+asking for plan review with no owner decision yet needs no context-log entry; the
+thread is the record until something converges.
+
 ### Feedback Retrieval Checklist
 Before claiming that all PR feedback was reviewed or addressed, inspect every
 available feedback surface:

--- a/scaffold/agent-vault/shared-rules.md
+++ b/scaffold/agent-vault/shared-rules.md
@@ -180,6 +180,7 @@ Use the canonical ordering for each artifact type below instead of guessing base
 - In committed memory artifacts, prefer repo-relative paths and portable command examples such as `agent-vault/...`, `docs/...`, `./scripts/...`, or `<repo-root>/...`. Machine-specific absolute paths such as `/Users/...`, `/home/...`, or `C:\...` are acceptable only when the local path itself is relevant debugging or environment context.
 - Create or update `agent-vault/daily/YYYY-MM-DD.md` on the first substantive work session of each local day. Reuse the same file for later sessions that day. Skip daily notes for trivial one-off requests.
 - Add a design-log note for every substantive work session.
+- Review-only external-feedback sessions that produced no converged project state follow the `Session End - Required` exception: skip the daily and design-log notes and say so in your final summary.
 - When a durable decision is made about architecture, workflow, API shape, data model, deployment, or tool policy, create a decision record in `agent-vault/decisions/` and add it to `agent-vault/decision-log.md`.
 - When handing off or pausing with meaningful unfinished work, create a handoff note in `agent-vault/context/handoffs/`, include a `Suggested Next Prompt`, and reference that note from `agent-vault/context-log.md`.
 - Use the standalone handoff prompt template only when a human explicitly asks for a copy-paste prompt. Otherwise keep the prompt inside the handoff note and the latest `context-log.md` entry.
@@ -251,6 +252,14 @@ When performing research or writing research-oriented documentation (design-log 
 - If handing off, add a note in `agent-vault/context/handoffs/`.
 - If the user corrected a mistake during this session, add an entry to `agent-vault/lessons.md` describing the mistake pattern and a preventive rule.
 - Before creating a commit for substantive work, make sure today's daily note, context log, and any new design-log entry do not leave same-session publication mechanics (`git commit`, `git push`, PR creation) in `Carry Forward`, `Next`, or equivalent future-tense text unless those actions will truly remain unfinished after the session.
+- Review-only / external-feedback exception: when the session's only durable output was feedback posted to an external thread (a GitHub issue, PR review, or doc comment thread) and nothing converged into project state, skip the project-memory writes above and say so in your final summary instead of writing empty artifacts. The external thread is the durable record of non-converged feedback; do not duplicate it into always-on memory. If the feedback surfaced a material trade-off awaiting an owner decision, the skip still applies unless active local work depends on the outcome — then add a one-line `agent-vault/open-questions.md` entry linking the thread. Example: plan-review feedback posted on a GitHub issue with no owner decision yet needs no context-log entry; the issue thread is the record until something converges.
+- For external feedback, write to project memory only when it converges into a durable state, then summarize the final outcome and link the external thread rather than copying comment text. Durable states:
+  - an accepted decision or owner-approved plan,
+  - an implemented or merged change,
+  - an unresolved blocker,
+  - a handoff with concrete remaining work,
+  - a reusable lesson or process rule, or
+  - an external-thread pointer that future agents need to resume active work or understand current project state.
 - Treat these updates as a commit gate for substantive work, not as optional cleanup after the code is already done.
 
 ## Direct Push to Main
@@ -262,7 +271,7 @@ When performing research or writing research-oriented documentation (design-log 
 ## Completion Verification - MUST follow before marking any task done
 Before reporting a task as finished:
 1. Run the Verification Loop appropriate to the repo and change scope.
-2. List the `agent-vault` artifacts created or updated this session, or explicitly state why no metadata update was required (for example, a trivial one-off request).
+2. List the `agent-vault` artifacts created or updated this session, or explicitly state why no metadata update was required (for example, a trivial one-off request, or a review-only session whose feedback lives in an external thread and did not converge into project state).
 3. Ask yourself: "Would a senior engineer approve this?" If not, fix it first.
 4. If any Verification Loop step was unavailable or could not run, explicitly state what was checked and what remains unverified.
 
@@ -307,7 +316,7 @@ Before considering any change complete and before running git commit:
   - `agent-vault/context/handoffs/` when handing off unfinished work
   - `agent-vault/lessons.md` when a corrected mistake should become a durable prevention rule
 - If the repo enables the tracked hooks under `agent-vault/_assets/hooks/`, keep them enabled via `git config core.hooksPath agent-vault/_assets/hooks`.
-- If a change is truly trivial and should not update project memory, make that an explicit decision and say so in your final summary instead of silently skipping the metadata step.
+- If a change is truly trivial and should not update project memory — including when the only staged change is trivial and the session's remaining output was non-converged external review feedback — make that an explicit decision and say so in your final summary instead of silently skipping the metadata step.
 
 ## Additional Guardrails
 - Prefer explicit diffs over whole-file rewrites when updating docs.

--- a/scaffold/root/AGENTS.md
+++ b/scaffold/root/AGENTS.md
@@ -342,6 +342,14 @@ If the platform or API blocks the intended formal review state (e.g., permission
 ## Responding to Review Feedback
 When asked to address review feedback in a PR comment, use a complete, itemized response.
 
+Transient external review feedback is not project memory: the issue/PR/doc thread
+is the durable record until feedback converges. Follow the review-only exception
+under `Session End - Required` in the shared agent rules for when a converged
+outcome should be recorded (summarize the outcome and link the thread; do not copy
+comment text into always-on memory). Example: feedback posted on a GitHub issue
+asking for plan review with no owner decision yet needs no context-log entry; the
+thread is the record until something converges.
+
 ### Feedback Retrieval Checklist
 Before claiming that all PR feedback was reviewed or addressed, inspect every
 available feedback surface:

--- a/scripts/test-context-log-policy-sync.sh
+++ b/scripts/test-context-log-policy-sync.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/agent-vault-context-log-policy-test.XXXXXX")"
+scaffold_context_log="$repo_root/scaffold/agent-vault/context-log.md"
+scaffold_context_log_template="$repo_root/scaffold/agent-vault/Templates/Context Log.md"
+rule_marker="- Review-only / external-feedback exception:"
+
+cleanup() {
+  rm -rf "$tmp_root"
+}
+
+trap cleanup EXIT
+
+assert_output_contains() {
+  local output="$1"
+  local expected_text="$2"
+
+  if [[ "$output" != *"$expected_text"* ]]; then
+    echo "Expected text not found in command output: $expected_text" >&2
+    echo "Actual output:" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+}
+
+assert_output_not_contains() {
+  local output="$1"
+  local unexpected_text="$2"
+
+  if [[ "$output" == *"$unexpected_text"* ]]; then
+    echo "Unexpected text found in command output: $unexpected_text" >&2
+    echo "Actual output:" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+}
+
+assert_file_contains() {
+  local file_path="$1"
+  local expected_text="$2"
+
+  if [[ "$(cat "$file_path")" != *"$expected_text"* ]]; then
+    echo "Expected text not found in file: $file_path" >&2
+    echo "Missing text: $expected_text" >&2
+    exit 1
+  fi
+}
+
+assert_files_equal() {
+  local left="$1"
+  local right="$2"
+
+  if ! cmp -s "$left" "$right"; then
+    echo "Expected files to match:" >&2
+    echo "  $left" >&2
+    echo "  $right" >&2
+    exit 1
+  fi
+}
+
+assert_file_exists() {
+  local file_path="$1"
+
+  if [[ ! -f "$file_path" ]]; then
+    echo "Expected file not found: $file_path" >&2
+    exit 1
+  fi
+}
+
+assert_rule_count() {
+  local file_path="$1"
+  local expected_count="$2"
+  local actual_count
+
+  actual_count="$(grep -cF -- "$rule_marker" "$file_path" || true)"
+  if [[ "$actual_count" != "$expected_count" ]]; then
+    echo "Expected $expected_count occurrence(s) of the review-only rule in $file_path; found $actual_count" >&2
+    exit 1
+  fi
+}
+
+assert_rule_inside_usage_rules() {
+  local file_path="$1"
+  local usage_line rule_line snapshot_line
+
+  usage_line="$(grep -nE '^## Usage Rules$' "$file_path" | head -n1 | cut -d: -f1)"
+  rule_line="$(grep -nF -- "$rule_marker" "$file_path" | head -n1 | cut -d: -f1)"
+  snapshot_line="$(grep -nE '^## Current Snapshot$' "$file_path" | head -n1 | cut -d: -f1)"
+
+  if [[ -z "$usage_line" || -z "$rule_line" || -z "$snapshot_line" ]]; then
+    echo "Missing expected sections/rule in $file_path" >&2
+    exit 1
+  fi
+  if [[ "$rule_line" -le "$usage_line" || "$rule_line" -ge "$snapshot_line" ]]; then
+    echo "Review-only rule is not inside the Usage Rules section in $file_path (usage=$usage_line rule=$rule_line snapshot=$snapshot_line)" >&2
+    exit 1
+  fi
+}
+
+init_repo() {
+  local repo_path="$1"
+
+  mkdir -p "$repo_path"
+  git -C "$repo_path" init >/dev/null
+}
+
+strip_rule_line() {
+  local src="$1"
+  local dest="$2"
+
+  grep -vF -- "$rule_marker" "$src" >"$dest"
+}
+
+# Scaffold sources must carry the rule for the sync/migration to distribute.
+assert_file_contains "$scaffold_context_log" "$rule_marker"
+assert_file_contains "$scaffold_context_log_template" "$rule_marker"
+
+# Case 1: a freshly generated project carries the rule in both the runtime
+# context log and the template (install path needs no migration).
+repo_path="$tmp_root/fresh-project"
+init_repo "$repo_path"
+"$repo_root/scripts/new-project.sh" "context-log-policy-test" "$repo_path" >/dev/null
+assert_file_contains "$repo_path/agent-vault/context-log.md" "$rule_marker"
+assert_file_contains "$repo_path/agent-vault/Templates/Context Log.md" "$rule_marker"
+assert_rule_inside_usage_rules "$repo_path/agent-vault/context-log.md"
+
+# Simulate a pre-existing project generated before the rule existed: strip the
+# rule from the runtime log and the template, and add a project-owned template
+# that normal updates must not touch.
+strip_rule_line "$repo_path/agent-vault/context-log.md" "$repo_path/agent-vault/context-log.md.stripped"
+mv "$repo_path/agent-vault/context-log.md.stripped" "$repo_path/agent-vault/context-log.md"
+strip_rule_line "$repo_path/agent-vault/Templates/Context Log.md" "$repo_path/agent-vault/Templates/Context Log.md.stripped"
+mv "$repo_path/agent-vault/Templates/Context Log.md.stripped" "$repo_path/agent-vault/Templates/Context Log.md"
+cat <<'EOF' >"$repo_path/agent-vault/Templates/Daily Note.md"
+# Custom Daily Template
+EOF
+cp "$repo_path/agent-vault/context-log.md" "$tmp_root/context-log-before-dry-run.md"
+
+# Case 2: dry run reports both updates without writing anything.
+dry_run_output="$("$repo_root/scripts/update-project.sh" "$repo_path" --dry-run 2>&1)"
+assert_output_contains "$dry_run_output" "Update: agent-vault/context-log.md (backup -> agent-vault/context/updates/"
+assert_output_contains "$dry_run_output" "Update: agent-vault/Templates/Context Log.md (backup -> agent-vault/context/updates/"
+assert_output_not_contains "$dry_run_output" "agent-vault/Templates/Daily Note.md"
+assert_files_equal "$repo_path/agent-vault/context-log.md" "$tmp_root/context-log-before-dry-run.md"
+assert_rule_count "$repo_path/agent-vault/Templates/Context Log.md" 0
+
+# Case 3: a normal update inserts the rule into the runtime Usage Rules,
+# refreshes the policy template, and leaves project-owned templates alone.
+default_output="$("$repo_root/scripts/update-project.sh" "$repo_path" 2>&1)"
+assert_output_contains "$default_output" "Updated: agent-vault/context-log.md"
+assert_output_contains "$default_output" "Updated: agent-vault/Templates/Context Log.md"
+assert_output_not_contains "$default_output" "agent-vault/Templates/Daily Note.md"
+assert_rule_count "$repo_path/agent-vault/context-log.md" 1
+assert_rule_inside_usage_rules "$repo_path/agent-vault/context-log.md"
+assert_files_equal "$scaffold_context_log_template" "$repo_path/agent-vault/Templates/Context Log.md"
+assert_file_contains "$repo_path/agent-vault/Templates/Daily Note.md" "# Custom Daily Template"
+context_log_backup="$(find "$repo_path/agent-vault/context/updates" -type f -path '*/agent-vault/context-log.md' | head -n1)"
+assert_file_exists "$context_log_backup"
+assert_rule_count "$context_log_backup" 0
+
+# The surgical insert must not disturb the rest of the runtime log.
+strip_rule_line "$repo_path/agent-vault/context-log.md" "$tmp_root/context-log-after-strip.md"
+assert_files_equal "$tmp_root/context-log-after-strip.md" "$tmp_root/context-log-before-dry-run.md"
+
+# Case 4: a second update is a no-op for the runtime log (idempotent).
+second_output="$("$repo_root/scripts/update-project.sh" "$repo_path" 2>&1)"
+assert_output_not_contains "$second_output" "Updated: agent-vault/context-log.md"
+assert_rule_count "$repo_path/agent-vault/context-log.md" 1
+
+# Case 5: a runtime log without a Usage Rules section is skipped with a notice
+# and left unchanged.
+no_rules_repo="$tmp_root/no-usage-rules-project"
+init_repo "$no_rules_repo"
+"$repo_root/scripts/new-project.sh" "context-log-no-rules-test" "$no_rules_repo" >/dev/null
+cat <<'EOF' >"$no_rules_repo/agent-vault/context-log.md"
+---
+type: context-log
+project: context-log-no-rules-test
+last_updated: 2026-01-01
+---
+
+# Context Log
+
+## Current Snapshot
+- Project: context-log-no-rules-test
+- Primary goal: Test fixture.
+- Current status: Minimal layout without usage rules.
+- Active branch: `main`
+- Last updated: 2026-01-01
+
+## Entries
+
+### 2026-01-01 09:00 local - test - fixture entry
+#### Goal
+Fixture.
+EOF
+cp "$no_rules_repo/agent-vault/context-log.md" "$tmp_root/no-rules-before.md"
+no_rules_output="$("$repo_root/scripts/update-project.sh" "$no_rules_repo" 2>&1)"
+assert_output_contains "$no_rules_output" "Skip: agent-vault/context-log.md review-only usage rule"
+assert_files_equal "$no_rules_repo/agent-vault/context-log.md" "$tmp_root/no-rules-before.md"
+
+# Case 6: a legacy-layout log whose prefix carries `## Usage Rules` gets the
+# layout migration but NOT the rule insert — the archived section below the new
+# snapshot must stay untouched and the migration must skip with a notice.
+legacy_repo="$tmp_root/legacy-usage-rules-project"
+init_repo "$legacy_repo"
+"$repo_root/scripts/new-project.sh" "context-log-legacy-test" "$legacy_repo" >/dev/null
+cat <<'EOF' >"$legacy_repo/agent-vault/context-log.md"
+---
+type: context-log
+project: context-log-legacy-test
+last_updated: 2026-03-25
+---
+
+# Context Log
+
+## Usage Rules
+- Newest entry at top.
+- Keep entries short and concrete.
+
+### 2026-03-25 12:40 local — tightened PR #193 after review feedback
+#### Goal
+Preserve a real legacy entry shape with the older em-dash separator.
+
+#### What Changed
+- Stored current-session entries before the late snapshot block.
+
+## Current Snapshot
+- Project: context-log-legacy-test
+- Primary goal: Preserve older generated context-log layout for migration testing.
+- Current status: Legacy fixture with a usage-rules section in the prefix.
+- Active branch: `main`
+- Last updated: 2026-03-25
+
+## Entries
+
+### 2026-03-21 19:43 local - codex - older indexed entry
+#### Goal
+Preserve a historical indexed entry below the late `## Entries` heading.
+EOF
+legacy_output="$("$repo_root/scripts/update-project.sh" "$legacy_repo" 2>&1)"
+assert_output_contains "$legacy_output" "Skip: agent-vault/context-log.md review-only usage rule"
+assert_rule_count "$legacy_repo/agent-vault/context-log.md" 0
+assert_file_contains "$legacy_repo/agent-vault/context-log.md" "## Legacy Unindexed Entries"
+
+# Case 7: --sync-templates must not double-sync the policy-managed template.
+strip_rule_line "$repo_path/agent-vault/Templates/Context Log.md" "$repo_path/agent-vault/Templates/Context Log.md.stripped"
+mv "$repo_path/agent-vault/Templates/Context Log.md.stripped" "$repo_path/agent-vault/Templates/Context Log.md"
+sync_templates_output="$("$repo_root/scripts/update-project.sh" "$repo_path" --sync-templates 2>&1)"
+template_mention_count="$(printf '%s\n' "$sync_templates_output" | grep -cF "agent-vault/Templates/Context Log.md" || true)"
+if [[ "$template_mention_count" != "1" ]]; then
+  echo "Expected exactly 1 output line for agent-vault/Templates/Context Log.md under --sync-templates; found $template_mention_count" >&2
+  printf '%s\n' "$sync_templates_output" >&2
+  exit 1
+fi
+assert_output_contains "$sync_templates_output" "Updated: agent-vault/Templates/Context Log.md"
+assert_files_equal "$scaffold_context_log_template" "$repo_path/agent-vault/Templates/Context Log.md"
+
+echo "context-log policy sync regression checks passed."

--- a/scripts/test-context-log-policy-sync.sh
+++ b/scripts/test-context-log-policy-sync.sh
@@ -260,4 +260,28 @@ fi
 assert_output_contains "$sync_templates_output" "Updated: agent-vault/Templates/Context Log.md"
 assert_files_equal "$scaffold_context_log_template" "$repo_path/agent-vault/Templates/Context Log.md"
 
+# Case 8: a symlinked policy-managed template must fail the upfront preflight
+# before any managed file or runtime migration is touched.
+symlink_repo="$tmp_root/symlinked-template-project"
+init_repo "$symlink_repo"
+"$repo_root/scripts/new-project.sh" "context-log-symlink-test" "$symlink_repo" >/dev/null
+strip_rule_line "$symlink_repo/agent-vault/context-log.md" "$symlink_repo/agent-vault/context-log.md.stripped"
+mv "$symlink_repo/agent-vault/context-log.md.stripped" "$symlink_repo/agent-vault/context-log.md"
+mv "$symlink_repo/agent-vault/Templates/Context Log.md" "$symlink_repo/agent-vault/context-log-template-target.md"
+ln -s "../context-log-template-target.md" "$symlink_repo/agent-vault/Templates/Context Log.md"
+symlink_rc=0
+symlink_output="$("$repo_root/scripts/update-project.sh" "$symlink_repo" 2>&1)" || symlink_rc=$?
+if [[ "$symlink_rc" -eq 0 ]]; then
+  echo "Expected update-project.sh to fail on a symlinked Templates/Context Log.md" >&2
+  printf '%s\n' "$symlink_output" >&2
+  exit 1
+fi
+assert_output_contains "$symlink_output" "managed file is a symlink, refusing to update: agent-vault/Templates/Context Log.md"
+assert_output_not_contains "$symlink_output" "Updated:"
+assert_rule_count "$symlink_repo/agent-vault/context-log.md" 0
+if [[ -d "$symlink_repo/agent-vault/context/updates" ]]; then
+  echo "Expected no backup directory after a failed preflight" >&2
+  exit 1
+fi
+
 echo "context-log policy sync regression checks passed."

--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -58,6 +58,7 @@ CHECK_CONTEXT_LOG_ROLLOVER_HELPER_MARKER="# agent-vault-managed: helper-script; 
 COMPACT_CONTEXT_LOG_HELPER_MARKER="# agent-vault-managed: helper-script; file=compact-context-log.sh"
 CHECK_LESSONS_ARCHIVE_HELPER_MARKER="# agent-vault-managed: helper-script; file=check-lessons-archive.sh"
 POLICY_TEMPLATE_REL_PATHS=(
+  "Context Log.md"
   "Decision Record.md"
 )
 
@@ -549,6 +550,77 @@ migrate_legacy_context_log_if_needed() {
   rm -f "$tmp_file"
 }
 
+# Insert the review-only / external-feedback usage rule (issue #129) into an
+# existing runtime context log that predates it. The rule line is read from the
+# scaffold context log so the migrated text cannot drift from the scaffold.
+migrate_context_log_usage_rules_if_needed() {
+  local file_path="$project_dir/context-log.md"
+  local rel="agent-vault/context-log.md"
+  local rule_marker="- Review-only / external-feedback exception:"
+  local rule_line=""
+  local usage_rules_line=""
+  local snapshot_line=""
+  local next_heading_offset=""
+  local section_end_line=""
+  local last_bullet_offset=""
+  local insert_after_line=""
+  local tmp_file=""
+
+  [[ -f "$file_path" ]] || return 0
+
+  if grep -Fq -- "$rule_marker" "$file_path"; then
+    return 0
+  fi
+
+  rule_line="$(grep -m1 -F -- "$rule_marker" "$vault_scaffold_dir/context-log.md" || true)"
+  if [[ -z "$rule_line" ]]; then
+    echo "Skip: $rel review-only usage rule (scaffold context log does not carry the rule line)"
+    skipped=$((skipped + 1))
+    return
+  fi
+
+  # Only edit an ACTIVE usage-rules section: it must sit above the current
+  # snapshot. A `## Usage Rules` heading below the snapshot belongs to archived
+  # historical content (for example after the legacy layout migration) and must
+  # be left untouched.
+  usage_rules_line="$(first_matching_line_number "$file_path" '^## Usage Rules$')"
+  snapshot_line="$(first_matching_line_number "$file_path" '^## Current Snapshot$')"
+  if [[ -z "$usage_rules_line" || -z "$snapshot_line" || "$usage_rules_line" -gt "$snapshot_line" ]]; then
+    echo "Skip: $rel review-only usage rule (no active \`## Usage Rules\` section above \`## Current Snapshot\`; copy the rule manually from the scaffold context log)"
+    skipped=$((skipped + 1))
+    return
+  fi
+
+  next_heading_offset="$(tail -n +$((usage_rules_line + 1)) "$file_path" | grep -nE '^#' | head -n1 | cut -d: -f1 || true)"
+  if [[ -n "$next_heading_offset" ]]; then
+    section_end_line=$((usage_rules_line + next_heading_offset - 1))
+  else
+    section_end_line="$(wc -l <"$file_path")"
+  fi
+
+  last_bullet_offset="$(sed -n "$((usage_rules_line + 1)),${section_end_line}p" "$file_path" | grep -nE '^- ' | tail -n1 | cut -d: -f1 || true)"
+  if [[ -z "$last_bullet_offset" ]]; then
+    echo "Skip: $rel review-only usage rule (no usage-rule bullets found; copy the rule manually from the scaffold context log)"
+    skipped=$((skipped + 1))
+    return
+  fi
+  insert_after_line=$((usage_rules_line + last_bullet_offset))
+
+  tmp_file="$(mktemp "${TMPDIR:-/tmp}/agent-vault-usage-rules-migration.XXXXXX")"
+  trap 'rm -f "$tmp_file"; trap - RETURN' RETURN
+
+  {
+    sed -n "1,${insert_after_line}p" "$file_path"
+    printf '%s\n' "$rule_line"
+    sed -n "$((insert_after_line + 1)),\$p" "$file_path"
+  } >"$tmp_file"
+
+  replace_file_from_tmp "$tmp_file" "$file_path"
+
+  trap - RETURN
+  rm -f "$tmp_file"
+}
+
 gitignore_has_line() {
   local file_path="$1"
   local target_line="$2"
@@ -971,6 +1043,7 @@ sync_managed_file "$vault_scaffold_dir/CLAUDE.md" "$project_dir/CLAUDE.md"
 sync_managed_file "$vault_scaffold_dir/GEMINI.md" "$project_dir/GEMINI.md"
 sync_managed_file "$vault_scaffold_dir/handoff.md" "$project_dir/handoff.md"
 migrate_legacy_context_log_if_needed
+migrate_context_log_usage_rules_if_needed
 sync_managed_file "$vault_scaffold_dir/_assets/hooks/README.md" "$project_dir/_assets/hooks/README.md"
 sync_managed_file "$vault_scaffold_dir/_assets/hooks/lib/runtime-note.sh" "$project_dir/_assets/hooks/lib/runtime-note.sh"
 sync_managed_executable_file "$vault_scaffold_dir/_assets/hooks/pre-commit" "$project_dir/_assets/hooks/pre-commit"
@@ -979,6 +1052,7 @@ sync_managed_file "$vault_scaffold_dir/design-log/README.md" "$project_dir/desig
 sync_managed_file "$vault_scaffold_dir/context/handoffs/README.md" "$project_dir/context/handoffs/README.md"
 sync_managed_file "$vault_scaffold_dir/decisions/README.md" "$project_dir/decisions/README.md"
 sync_managed_file "$vault_scaffold_dir/daily/README.md" "$project_dir/daily/README.md"
+sync_managed_file "$vault_scaffold_dir/Templates/Context Log.md" "$project_dir/Templates/Context Log.md"
 sync_managed_file "$vault_scaffold_dir/Templates/Decision Record.md" "$project_dir/Templates/Decision Record.md"
 
 seed_if_missing "$vault_scaffold_dir/lessons.md" "$project_dir/lessons.md"

--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -161,6 +161,7 @@ for required in \
   "$vault_scaffold_dir/context/handoffs/README.md" \
   "$vault_scaffold_dir/decisions/README.md" \
   "$vault_scaffold_dir/daily/README.md" \
+  "$vault_scaffold_dir/Templates/Context Log.md" \
   "$vault_scaffold_dir/Templates/Decision Record.md"; do
   if [[ ! -f "$required" ]]; then
     echo "Error: missing scaffold file: $required"
@@ -239,6 +240,7 @@ preflight_symlink_checks() {
   assert_not_symlink "$project_dir/context/handoffs/README.md" "agent-vault/context/handoffs/README.md"
   assert_not_symlink "$project_dir/decisions/README.md" "agent-vault/decisions/README.md"
   assert_not_symlink "$project_dir/daily/README.md" "agent-vault/daily/README.md"
+  assert_not_symlink "$project_dir/Templates/Context Log.md" "agent-vault/Templates/Context Log.md"
   assert_not_symlink "$project_dir/Templates/Decision Record.md" "agent-vault/Templates/Decision Record.md"
   assert_not_symlink "$canonical_repo_path/.gitignore" ".gitignore"
 }


### PR DESCRIPTION
> 🤖 **Post by Claude Fable 5** · via Claude Code

Closes #129.

## Summary

Implements the owner-approved amended plan (v2) from the #129 thread: review-only sessions whose only durable output is non-converged feedback on an external thread (GitHub issue, PR review, doc comment thread) now explicitly skip the session-end project-memory writes, and memory is written only when feedback converges into a durable state (accepted decision / owner-approved plan, implemented or merged change, unresolved blocker, handoff, reusable lesson, or a pointer future agents need). A pending owner decision gets an `open-questions.md` pointer only when active local work depends on the outcome — otherwise the thread is the record.

Per the owner's follow-up instruction, this PR also goes one step beyond the v2 PR note ("residual wording drift in existing projects is expected") and makes `update-project.sh` migrate existing repos: `Templates/Context Log.md` is promoted to an always-managed policy template (Decision Record precedent), and a new idempotent migration inserts the review-only usage rule into an existing runtime `context-log.md`'s active `## Usage Rules` section, copying the line verbatim from the scaffold. This scope expansion supersedes the v2 propagation posture and is recorded here so the plan and shipped behavior reconcile on the thread.

## Files / areas changed

**Policy prose (commit 1):**
- `scaffold/agent-vault/shared-rules.md` + `scaffold/agent-vault/AGENTS.md` (byte-identical mirror pair): Session-End carve-out with durable-state list and example; Template Usage Rules qualifier; Completion Verification item 2 extension; Metadata Gate carve-out extension. The v2 wording was reformatted to the file's single-line-bullet idiom; substance unchanged.
- `scaffold/agent-vault/review-policy.md` + `scaffold/root/AGENTS.md` + root `AGENTS.md` (mirror pairs A/C): cross-reference + example under `## Responding to Review Feedback` (deliberately path-free — no mirror alias exists for `shared-rules.md`).
- Non-mirrored checklist surfaces: `handoff.md` (Required Artifacts + the fenced Suggested Next Prompt), `daily/README.md`, `context-log.md` + `Templates/Context Log.md` usage rules, `_assets/hooks/README.md` (Intentional Bypass now covers review-only sessions committing a trivial change).

**Scripts / tests / docs (commit 2):**
- `scripts/update-project.sh`: `Context Log.md` added to `POLICY_TEMPLATE_REL_PATHS` + always-managed sync line; new `migrate_context_log_usage_rules_if_needed` (runs after the legacy layout migration; inserts only into an active `## Usage Rules` section above `## Current Snapshot`; bullet scan stops at any heading so archived legacy content is never touched; unrecognized layouts skip with a notice; every write is backed up under `agent-vault/context/updates/<timestamp>/` and dry-run aware).
- `scripts/test-context-log-policy-sync.sh` (new): fresh-install coverage, dry-run, insert-position assertion, idempotency, no-usage-rules skip, legacy-layout interplay (archived `## Usage Rules` untouched), `--sync-templates` single-sync.
- `.github/workflows/scaffold-regression-checks.yml`: new test registered (both path filters + step).
- `README.md`: always-managed list, policy-template parenthetical, regression-check list, and migration notes updated to match.
- `scripts/new-project.sh` needs no change: it copies the scaffold verbatim and the new prose contains no placeholder tokens (covered by the new test's fresh-install case).

## Verification

Run locally (macOS, bash 3.2):
- `bash scripts/check-policy-mirrors.sh` — pass (pairs A/B/C, no drift).
- `bash scripts/test-session-start-load-contract.sh` — pass (includes the mirror re-check).
- `bash scripts/test-context-log-policy-sync.sh` — pass (all 7 cases).
- `bash scripts/test-decision-template-sync.sh`, `test-session-metadata-hook.sh`, `test-coding-standards-sync.sh`, `test-gitignore-management.sh`, `test-main-push-gate.sh` — pass.
- `bash scripts/check-style.sh` — pass (33 shell files, ShellCheck + shfmt).
- Not run locally: `test-check-context-log-rollover.sh`, `test-compact-context-log.sh`, `test-memory-budget-hook.sh` fail on macOS bash 3.2 (`mapfile` / `declare -A`) identically on `main` — pre-existing environment limitation; they run in CI on Ubuntu.
- An adversarial two-agent review of the staged diff was run before commit; its critical findings (stale README, legacy-layout insertion guard) are fixed and regression-tested in this PR.

**Memory-budget accounting** (per the v2 validation note): `shared-rules.md` 31,491 → 33,284 B and `agent-vault/AGENTS.md` 31,681 → 33,474 B (+1,793 each, pair B); `review-policy.md` 18,039 → 18,574 B (+535, ×3 copies across pairs A/C). All files remain under the 40,000 B per-file budget; the generated-project Claude `@`-chain moves to ~55 KB against the 120,000 B chain budget. `agent-vault/AGENTS.md` now exceeds the Codex `project_doc_max_bytes` 32 KiB default, which is informational: at a repo-root cwd the file is protocol-read, not startup-concatenated; the cap only applies when the cwd ancestry includes `agent-vault/`.

## Risks / rollback

- Mirror desync is the main hazard for future edits; this PR keeps all copies byte-identical and CI enforces it (`policy-mirror-check.yml`, scaffold regression suite).
- The runtime context-log migration edits project memory in existing repos: it is additive (one usage-rule bullet), idempotent, backed up, and guarded against legacy/archived layouts; unrecognized layouts are skipped with a notice. Projects that customized `Templates/Context Log.md` will now have it refreshed on normal updates (with backup) — the behavior change is documented in README.
- Rollback: revert the two commits; no state migration to undo beyond restoring backups in already-updated projects.

## Docs consistency

Updated `README.md` (managed-file list, policy templates, regression checks, migration notes). No `docs/design.md` exists at the repo root; scaffold docs are unaffected. Generated-project behavior and scaffold files were modified together per repo policy.
