### PR TITLE
Fix AGENTS.md discovery on BSD find in non-git repos

### DIFF
--- a/scaffold/root/scripts/check-memory-budget.sh
+++ b/scaffold/root/scripts/check-memory-budget.sh
@@ -306,7 +306,9 @@ discover_agents_files() {
     git -C "$repo" -c core.quotePath=false ls-files -z --cached --others --exclude-standard \
       -- 'AGENTS.md' '**/AGENTS.md' 2>/dev/null | sort -zu | tr '\0' '\n'
   else
-    (cd "$repo" && find . -name AGENTS.md -not -path '*/.git/*' -printf '%P\n' 2>/dev/null | sort -u)
+    # BSD find has no -printf; strip the leading "./" so paths stay
+    # repo-relative for exception matching and display parity with git ls-files.
+    (cd "$repo" && find . -name AGENTS.md -not -path '*/.git/*' 2>/dev/null | sed 's|^\./||' | sort -u)
   fi
 }
 

--- a/scripts/test-check-memory-budget.sh
+++ b/scripts/test-check-memory-budget.sh
@@ -259,6 +259,17 @@ printf 'root\n' >"$nongit/AGENTS.md"
 printf 'nested\n' >"$nongit/sub/AGENTS.md"
 mapfile -t nongit_agents < <(tsv_bucket "$nongit" agents)
 assert_in_set "sub/AGENTS.md" "${nongit_agents[@]}"
+# The root file must appear WITHOUT a "./" prefix: exception matching and the
+# git-branch output are keyed by clean repo-relative paths (regression: the
+# GNU-only "find -printf '%P\n'" fallback returned nothing on BSD userland).
+assert_in_set "AGENTS.md" "${nongit_agents[@]}"
+assert_not_in_set "./AGENTS.md" "${nongit_agents[@]}"
+
+# The pre-commit hook's staged-checkout path is a non-git directory: an
+# over-budget AGENTS.md there must still trip --strict.
+head -c 45000 /dev/zero | tr '\0' 'a' >"$nongit/sub/AGENTS.md"
+expect_result 1 "over file budget" --repo "$nongit" --strict
+printf 'nested\n' >"$nongit/sub/AGENTS.md"
 
 # A .gitignore'd AGENTS.md is excluded in a git repo.
 printf 'ignored/\n' >"$project/.gitignore"


### PR DESCRIPTION
> 🤖 **Post by Claude Fable 5** · via Claude Code

## Summary

`check-memory-budget.sh`'s non-git AGENTS.md discovery fallback used GNU-only `find -printf '%P\n'`, which BSD `find` on macOS rejects (`-printf: unknown primary or operator`). The failure was doubly swallowed — stderr discarded, and the pipeline runs inside a process substitution whose exit status is never checked — so the Codex AGENTS bucket silently reported `MISSING (no AGENTS.md found)` and an over-budget `AGENTS.md` never tripped `--strict`. This is exactly the path the tracked pre-commit hook exercises: it materializes the index via `git checkout-index` into a temp directory (no `.git`), then runs `check-memory-budget.sh --repo <staged_root> --strict`. On macOS the staged memory-budget warning could therefore never fire for an AGENTS.md overage.

Found by a Cursor Grok 4.5 review of a downstream scaffold sync in a private consumer repo; reproduction confirmed independently before fixing.

## Files / areas changed

- `scaffold/root/scripts/check-memory-budget.sh`: replace the GNU-only `-printf '%P\n'` with a portable `find . | sed 's|^\./||' | sort -u` pipe. The `sed` strip is load-bearing: a bare `-print` emits `./AGENTS.md`, which still measures bytes correctly but breaks exceptions-file matching (keyed by clean repo-relative paths) and display parity with the git branch.
- `scripts/test-check-memory-budget.sh`: the existing non-git discovery assertion (`sub/AGENTS.md`) failed on stock macOS before this fix and passes after. Added: root `AGENTS.md` must be discovered without a `./` prefix (guards against a naive `-print`-only fix), and an over-budget AGENTS.md in a non-git directory must fail `--strict` with `over file budget` (pins the hook's exact scenario).

## Verification

Run locally (macOS, BSD userland, Homebrew bash 5.3):
- `bash scripts/test-check-memory-budget.sh` — pass (failed on `main` on this machine at the non-git discovery assertion before the fix).
- `bash scripts/check-style.sh` — pass (ShellCheck + shfmt).
- Manual repro: non-git dir with a 45,000-byte `agent-vault/AGENTS.md` (budget 40,000) — before: `MISSING` + `Within budget` + exit 0; after: `OVER ... over file budget (40000 bytes)` + strict exit 1.

## Risks / rollback

- Risk: low — one-line behavioral change confined to the non-git fallback branch; the git-repo branch (`git ls-files`, incl. `sort -zu`) is untouched and verified working on macOS.
- Residual gap: CI (`scaffold-regression-checks.yml`) runs on `ubuntu-latest` with GNU find, which is why this never surfaced there. Worth considering a `macos-latest` job for the shell suites as a follow-up; not included to keep this PR scoped.
- Rollback: revert the single commit.

## Docs Consistency

- `docs/memory-budgets.md` describes the fallback behaviorally ("a plain filesystem walk") — still accurate; no update needed.
- `README.md`: no impact (no CLI or usage change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
