### PR TITLE
Restrict rollover entry boundaries to canonical entry headings

### DIFF
--- a/scaffold/root/scripts/check-context-log-rollover.sh
+++ b/scaffold/root/scripts/check-context-log-rollover.sh
@@ -26,6 +26,11 @@ Checks (live context log; headings matched outside fenced code blocks):
   - if the snapshot declares a latest-handoff pointer, it has an inline value
 Checks (when --archive is given):
   - every archived "## Current Snapshot" is labeled superseded
+  - no dated heading sits above the archive's first canonical entry heading
+    (a torn entry fragment), and every dated heading of depth 1-3 is a
+    canonical entry heading (noncanonical legacy entries would be invisible
+    to boundary validation); dated sub-headings of depth 4+ inside an entry
+    remain legal body text
 Checks (when --manifest is given -- Layer-2 rollover assertions):
   - the live Current Snapshot's "Context-log rollover" pointer references the
     newest manifest record's id and repeats its boundary text verbatim
@@ -205,6 +210,45 @@ inspect_archive_superseded() {
   ' "$1"
 }
 
+# Prints "<line>\t<kind>\t<heading>" for archive dated headings (outside fences)
+# that the strict boundary scan cannot treat as entries:
+#   fragment     -- any dated heading before the first canonical entry heading;
+#                   only header prose belongs there, so this is the signature of
+#                   an entry torn apart by a bad split (or a misplaced paste)
+#   noncanonical -- a depth-1..3 heading whose text starts with a YYYY-MM-DD
+#                   date but is not canonical (legacy or hand-written entry the
+#                   boundary scan would silently skip)
+# Dated sub-headings of depth 4+ inside an entry are legal body text.
+inspect_archive_dated_headings() {
+  awk '
+    function strip(s) {
+      sub(/\r$/, "", s)
+      sub(/^[[:space:]]+/, "", s)
+      sub(/[[:space:]]+$/, "", s)
+      return s
+    }
+    /^(```|~~~)/ { in_fence = !in_fence; next }
+    {
+      if (in_fence) next
+      line = strip($0)
+      if (line !~ /^#+[[:space:]]/) next
+      text = line
+      sub(/^#+[[:space:]]+/, "", text)
+      if (text !~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) next
+      if (line ~ /^### [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9] local - /) {
+        seen_entry = 1
+        next
+      }
+      if (!seen_entry) {
+        printf "%d\tfragment\t%s\n", NR, line
+        next
+      }
+      match(line, /^#+/)
+      if (RLENGTH <= 3) printf "%d\tnoncanonical\t%s\n", NR, line
+    }
+  ' "$1"
+}
+
 # --- Layer-2 (rollover manifest) helpers ---------------------------------
 # These run only when --manifest is given. They verify the live pointer's claim
 # against the manifest, and the manifest's claims against archive reality, so a
@@ -362,6 +406,18 @@ if [[ -n "$archive_file" ]]; then
     [[ -n "$row" ]] || continue
     findings+=("archived snapshot is not labeled superseded (archive line ${row%%$'\t'*}) -- archived snapshots must be marked superseded so they cannot read as active")
   done < <(inspect_archive_superseded "$archive_file")
+
+  while IFS=$'\t' read -r row_line row_kind row_heading; do
+    [[ -n "$row_line" ]] || continue
+    case "$row_kind" in
+      fragment)
+        findings+=("archive has a dated heading above its first entry (archive line $row_line): \"$row_heading\" -- looks like a torn entry fragment; only header prose belongs above the first canonical \"### YYYY-MM-DD HH:MM local - ...\" heading")
+        ;;
+      noncanonical)
+        findings+=("archive has a noncanonical dated entry heading (archive line $row_line): \"$row_heading\" -- normalize it to \"### YYYY-MM-DD HH:MM local - <agent> - <topic>\" so boundary validation can see it")
+        ;;
+    esac
+  done < <(inspect_archive_dated_headings "$archive_file")
 fi
 
 if [[ -n "$manifest_file" ]]; then

--- a/scaffold/root/scripts/check-context-log-rollover.sh
+++ b/scaffold/root/scripts/check-context-log-rollover.sh
@@ -36,7 +36,9 @@ Checks (when --manifest is given -- Layer-2 rollover assertions):
 
 Section headings are matched exactly (a distinct heading such as
 "## Current Snapshot Format Notes" is not a duplicate), and CRLF line endings
-are tolerated. Entry heading styles inside "## Entries" are not constrained.
+are tolerated. Live entry-heading style is enforced by the pre-commit hook, not
+here; archive boundary verification counts only canonical
+"### YYYY-MM-DD HH:MM local - <agent> - <topic>" entry headings.
 
 The rollover manifest (parsed source of truth) holds one record per rollover,
 newest first. All fields are required; the *_archived headings are the entry
@@ -278,8 +280,10 @@ parse_live_pointer() {
 }
 
 # Archive entry-heading extremes + presence of the named newest/oldest headings.
-# An "entry heading" is any heading (outside a fence) whose text starts with a
-# YYYY-MM-DD date; timestamps normalize to "YYYY-MM-DD HH:MM" (00:00 if no time)
+# An "entry heading" is a canonical "### YYYY-MM-DD HH:MM local - <agent> -
+# <topic>" heading outside a fence (the shape the pre-commit hook enforces and
+# the compactor splits on); a nested sub-heading that merely starts with a date
+# is body text, not a boundary. The leading "YYYY-MM-DD HH:MM" is the timestamp,
 # so lexical compare gives chronological order and a shared minute is unambiguous.
 verify_archive_boundaries() {
   awk -v newest="$1" -v oldest="$2" '
@@ -289,22 +293,14 @@ verify_archive_boundaries() {
       sub(/[[:space:]]+$/, "", s)
       return s
     }
-    function entry_ts(text,   d, rest, t) {
-      d = substr(text, 1, 10)
-      rest = substr(text, 11)
-      if (match(rest, /[0-9][0-9]:[0-9][0-9]/)) t = substr(rest, RSTART, 5)
-      else t = "00:00"
-      return d " " t
-    }
     /^(```|~~~)/ { in_fence = !in_fence; next }
     {
       if (in_fence) next
       line = strip($0)
-      # mawk has no interval expressions ({1,6}); "#+" matches any heading depth.
-      if (line !~ /^#+[[:space:]]/) next
-      sub(/^#+[[:space:]]+/, "", line)
-      if (line !~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) next
-      ts = entry_ts(line)
+      # mawk has no interval expressions ({4}), so digits are spelled out.
+      if (line !~ /^### [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9] local - /) next
+      sub(/^### /, "", line)
+      ts = substr(line, 1, 16)
       n++
       # The newest entry is the top-most at the max timestamp and the oldest is
       # the bottom-most at the min timestamp (archives are newest-at-top). Ties

--- a/scaffold/root/scripts/compact-context-log.sh
+++ b/scaffold/root/scripts/compact-context-log.sh
@@ -183,6 +183,9 @@ strip_trailing_blanks() {
 }
 
 # Entry-heading line numbers inside the "## Entries" section (fence-aware).
+# Only canonical entry headings ("### YYYY-MM-DD HH:MM local - <agent> - <topic>",
+# the shape the pre-commit hook enforces) count: a nested sub-heading that merely
+# starts with a date must never become a split boundary or inflate the entry count.
 entry_heading_lines() {
   awk '
     /^(```|~~~)/ { in_fence = !in_fence; next }
@@ -191,9 +194,8 @@ entry_heading_lines() {
       line = $0; sub(/\r$/, "", line)
       if (line ~ /^## Entries[[:space:]]*$/) { in_entries = 1; next }
       if (!in_entries) next
-      if (line !~ /^#+[[:space:]]/) next
-      htext = line; sub(/^#+[[:space:]]+/, "", htext)
-      if (htext ~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) print NR
+      if (line !~ /^### [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9] local - /) next
+      print NR
     }
   ' "$1"
 }
@@ -212,17 +214,17 @@ inject_pointer() {
   ' "$2"
 }
 
-# Split a file at the first entry heading: prints "HEADER\n<n>" where line <n> is
-# the first dated heading (or 0 if none), so the caller can slice header/entries.
+# Split a file at the first entry heading: prints the line number of the first
+# canonical entry heading (nothing if none), so the caller can slice header/entries.
 first_entry_line() {
   awk '
     /^(```|~~~)/ { in_fence = !in_fence; next }
     {
       if (in_fence) next
       line = $0; sub(/\r$/, "", line)
-      if (line !~ /^#+[[:space:]]/) next
-      htext = line; sub(/^#+[[:space:]]+/, "", htext)
-      if (htext ~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) { print NR; exit }
+      if (line !~ /^### [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9] local - /) next
+      print NR
+      exit
     }
     END { }
   ' "$1"
@@ -233,20 +235,13 @@ first_entry_line() {
 # top-most at the max minute, oldest = bottom-most at the min minute).
 select_boundaries() {
   awk '
-    function entry_ts(text,   d, rest, t) {
-      d = substr(text, 1, 10); rest = substr(text, 11)
-      if (match(rest, /[0-9][0-9]:[0-9][0-9]/)) t = substr(rest, RSTART, 5)
-      else t = "00:00"
-      return d " " t
-    }
     /^(```|~~~)/ { in_fence = !in_fence; next }
     {
       if (in_fence) next
       line = $0; sub(/\r$/, "", line)
-      if (line !~ /^#+[[:space:]]/) next
-      sub(/^#+[[:space:]]+/, "", line)
-      if (line !~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) next
-      ts = entry_ts(line); n++
+      if (line !~ /^### [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9] local - /) next
+      sub(/^### /, "", line)
+      ts = substr(line, 1, 16); n++
       if (n == 1 || ts > max_ts) { max_ts = ts; max_h = line }
       if (n == 1 || ts <= min_ts) { min_ts = ts; min_h = line }
     }

--- a/scaffold/root/scripts/compact-context-log.sh
+++ b/scaffold/root/scripts/compact-context-log.sh
@@ -316,8 +316,16 @@ manifest_canon="$(canonical_path "$manifest_file")"
 [[ "$log_canon" != "$manifest_canon" ]] || die "--manifest must differ from the context log ($manifest_file)"
 [[ "$archive_canon" != "$manifest_canon" ]] || die "--archive and --manifest must differ ($archive_file)"
 
-# Structure must be sound before we rearrange it.
-if ! "$checker" "$context_log" --quiet >/dev/null 2>&1; then
+# Structure must be sound before we rearrange it. An existing archive must
+# validate too: dated headings the strict boundary scan cannot see (torn
+# fragments, noncanonical legacy entries) would otherwise be treated as header
+# prose and silently reordered above the newer batch.
+checker_args=("$context_log")
+[[ -f "$archive_file" ]] && checker_args+=(--archive "$archive_file")
+if ! "$checker" "${checker_args[@]}" --quiet >/dev/null 2>&1; then
+  if [[ -f "$archive_file" ]]; then
+    abort "context log or existing archive fails the structural rollover check; run check-context-log-rollover.sh $context_log --archive $archive_file and normalize before rolling over"
+  fi
   abort "context log fails the structural rollover check; run check-context-log-rollover.sh $context_log"
 fi
 

--- a/scripts/test-check-context-log-rollover.sh
+++ b/scripts/test-check-context-log-rollover.sh
@@ -775,6 +775,27 @@ EOF
 expect_result 1 "was not found next to the manifest" \
   "$tmp_root/good-rollover-live.md" --manifest "$tmp_root/manifest-lonely.md"
 
+# A nested date-prefixed sub-heading inside an archived entry is body text: it
+# must not disturb boundary verification (regression: the loose matcher counted
+# it as an entry, so a compactor split on it self-validated).
+mkdir -p "$tmp_root/nested-dated"
+awk '/^#### State$/ { print; print "#### 2026-05-29 follow-up (same-day fix)"; next } { print }' \
+  "$tmp_root/context-log-2026.md" >"$tmp_root/nested-dated/context-log-2026.md"
+expect_result 0 "passed" "$tmp_root/good-rollover-live.md" \
+  --archive "$tmp_root/nested-dated/context-log-2026.md" --manifest "$tmp_root/manifest-good.md"
+
+# An archive that STARTS with an orphaned "#### <date>" fragment (what a
+# corrupted mid-entry split produces), with a manifest citing the fragment as
+# newest_archived, must FAIL: the fragment is not a canonical entry heading.
+mkdir -p "$tmp_root/fragment-top"
+awk '/^### 2026-05-29 17:00/ { print "#### 2026-05-30 follow-up fragment"; print "- Torn from its parent entry."; print ""; print $0; next } { print }' \
+  "$tmp_root/context-log-2026.md" >"$tmp_root/fragment-top/context-log-2026.md"
+sed 's/^- newest_archived: .*/- newest_archived: 2026-05-30 follow-up fragment/' \
+  "$tmp_root/manifest-good.md" >"$tmp_root/manifest-fragment.md"
+expect_result 1 "newest_archived heading not found in the archive" \
+  "$tmp_root/good-rollover-live.md" \
+  --archive "$tmp_root/fragment-top/context-log-2026.md" --manifest "$tmp_root/manifest-fragment.md"
+
 # A missing manifest file is an IO error.
 expect_result 2 "manifest file not found" \
   "$tmp_root/good-rollover-live.md" --manifest "$tmp_root/does-not-exist-manifest.md"

--- a/scripts/test-check-context-log-rollover.sh
+++ b/scripts/test-check-context-log-rollover.sh
@@ -796,6 +796,23 @@ expect_result 1 "newest_archived heading not found in the archive" \
   "$tmp_root/good-rollover-live.md" \
   --archive "$tmp_root/fragment-top/context-log-2026.md" --manifest "$tmp_root/manifest-fragment.md"
 
+# A depth-1..3 dated heading that is not a canonical entry heading (legacy or
+# hand-written style) must fail: the boundary scan cannot see such entries.
+{
+  cat "$tmp_root/context-log-2026.md"
+  printf '\n## 2026-01-02 - legacy tail entry\n- Old-style body.\n'
+} >"$tmp_root/archive-noncanonical.md"
+expect_result 1 "noncanonical dated entry heading" \
+  "$tmp_root/good-live.md" --archive "$tmp_root/archive-noncanonical.md"
+
+# ANY dated heading above the archive's first canonical entry is a torn-entry
+# fragment (only header prose belongs there), even at sub-heading depth and
+# even when no manifest cites it.
+awk '/^### 2026-05-29 17:00/ && !done { print "#### 2026-05-30 orphaned fragment"; print "- Torn body."; print ""; done = 1 } { print }' \
+  "$tmp_root/context-log-2026.md" >"$tmp_root/archive-header-fragment.md"
+expect_result 1 "above its first entry" \
+  "$tmp_root/good-live.md" --archive "$tmp_root/archive-header-fragment.md"
+
 # A missing manifest file is an IO error.
 expect_result 2 "manifest file not found" \
   "$tmp_root/good-rollover-live.md" --manifest "$tmp_root/does-not-exist-manifest.md"

--- a/scripts/test-compact-context-log.sh
+++ b/scripts/test-compact-context-log.sh
@@ -48,14 +48,13 @@ assert_not_exists() {
   pass=$((pass + 1))
 }
 
-# Count dated entry headings in a file (### or compact ## with a leading date).
+# Count canonical entry headings in a file (the same strict shape the compactor
+# and checker split on; nested date-prefixed sub-headings must not count).
 count_entries() {
   awk '
     /^(```|~~~)/ { f = !f; next }
     { if (f) next; l = $0; sub(/\r$/, "", l)
-      if (l !~ /^#+[[:space:]]/) next
-      sub(/^#+[[:space:]]+/, "", l)
-      if (l ~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) c++ }
+      if (l ~ /^### [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9] local - /) c++ }
     END { print c + 0 }
   ' "$1"
 }
@@ -628,5 +627,80 @@ old_ln="$(grep -n '^## rollover: 2026-05-01-1' "$d/archive/manifest.md" | head -
 [[ -n "$new_ln" && -n "$old_ln" && "$new_ln" -lt "$old_ln" ]] ||
   fail "headerless manifest: new record must be newest-first above the pre-existing record"
 pass=$((pass + 1))
+
+# --- Nested date-prefixed sub-heading is body text, not an entry boundary --
+# (regression: the loose matcher counted any heading starting with a date, so a
+# "#### <date> ..." sub-heading landing at the keep boundary split its parent
+# entry mid-body, and the checker's identical matcher passed the corrupted result)
+make_nested_log() {
+  cat >"$1" <<'EOF'
+# Context Log
+
+## Usage Rules
+- Newest entry at top.
+
+## Current Snapshot
+- Active branch: `main`
+- Last updated: 2026-05-30
+
+## Entries
+
+### 2026-05-30 09:00 local - claude - rollover session entry
+#### State
+- Bookkeeping for the rollover.
+
+### 2026-05-29 11:00 local - claude - feature work
+- Implemented X.
+
+#### 2026-05-29 follow-up
+- Fixed the import edge case later the same day; belongs to the entry above.
+
+### 2026-05-28 10:00 local - codex - older work
+- Body.
+
+### 2026-05-27 10:00 local - gemini - older still
+- Body.
+EOF
+}
+d="$tmp_root/nested"
+mkdir -p "$d/archive"
+make_nested_log "$d/log.md"
+# --keep 2: with the loose matcher the nested heading was the 3rd "entry" and
+# became the split line, tearing "feature work" apart.
+run_compact "$d/log.md" --keep 2 --archive "$d/archive/context-log-2026.md" \
+  --manifest "$d/archive/manifest.md" --rollover-id 2026-05-31-1 \
+  --require-top-entry "rollover session"
+assert_rc 0 "$COMPACT_RC" "nested heading rollover"
+assert_contains "$COMPACT_OUT" "kept 2, archived 2" "nested: only real entries counted"
+# The kept "feature work" entry keeps its nested sub-heading; the archive gets
+# whole entries and must not start with an orphaned "####" fragment.
+assert_file_contains "$d/log.md" "#### 2026-05-29 follow-up" "nested: sub-heading stays with kept entry"
+[[ "$(head -c 4 "$d/archive/context-log-2026.md")" != "####" ]] ||
+  fail "nested: archive must not start with an orphaned fragment"
+pass=$((pass + 1))
+[[ "$(count_entries "$d/log.md")" -eq 2 ]] || fail "nested: live log should keep 2 entries"
+pass=$((pass + 1))
+[[ "$(count_entries "$d/archive/context-log-2026.md")" -eq 2 ]] || fail "nested: archive should hold 2 entries"
+pass=$((pass + 1))
+assert_file_contains "$d/archive/manifest.md" \
+  "- newest_archived: 2026-05-28 10:00 local - codex - older work" "nested: boundary is a real entry"
+"$checker" "$d/log.md" --archive "$d/archive/context-log-2026.md" \
+  --manifest "$d/archive/manifest.md" >/dev/null || fail "nested: checker rejected the result"
+pass=$((pass + 1))
+
+# --- Nested dated heading must not inflate the rollover trigger ------------
+# (regression: 4 real entries + 1 nested dated heading counted as 5, so
+# --keep 4 rolled over a should-be no-op log and archived only the fragment)
+d="$tmp_root/nested-noop"
+mkdir -p "$d/archive"
+make_nested_log "$d/log.md"
+before="$(cksum "$d/log.md")"
+run_compact "$d/log.md" --keep 4 --archive "$d/archive/context-log-2026.md" \
+  --manifest "$d/archive/manifest.md" --rollover-id x --require-top-entry "rollover session"
+assert_rc 0 "$COMPACT_RC" "nested no-op keep==real total"
+assert_contains "$COMPACT_OUT" "Nothing to roll over" "nested no-op message"
+[[ "$(cksum "$d/log.md")" == "$before" ]] || fail "nested no-op: live log must be unchanged"
+pass=$((pass + 1))
+assert_not_exists "$d/archive/manifest.md" "nested no-op: no manifest written"
 
 echo "compact-context-log compactor regression checks passed ($pass assertions)."

--- a/scripts/test-compact-context-log.sh
+++ b/scripts/test-compact-context-log.sh
@@ -677,10 +677,19 @@ run_compact "$d/log.md" --keep 2 --archive "$d/archive/context-log-2026.md" \
 assert_rc 0 "$COMPACT_RC" "nested heading rollover"
 assert_contains "$COMPACT_OUT" "kept 2, archived 2" "nested: only real entries counted"
 # The kept "feature work" entry keeps its nested sub-heading; the archive gets
-# whole entries and must not start with an orphaned "####" fragment.
+# whole entries, so its first dated heading (after the archive header) must be
+# the canonical boundary entry -- an orphaned "#### <date>" fragment would
+# surface here as the first dated heading.
 assert_file_contains "$d/log.md" "#### 2026-05-29 follow-up" "nested: sub-heading stays with kept entry"
-[[ "$(head -c 4 "$d/archive/context-log-2026.md")" != "####" ]] ||
-  fail "nested: archive must not start with an orphaned fragment"
+first_dated_heading="$(awk '
+  /^(```|~~~)/ { f = !f; next }
+  { if (f) next; l = $0; sub(/\r$/, "", l)
+    if (l !~ /^#+[[:space:]]/) next
+    t = l; sub(/^#+[[:space:]]+/, "", t)
+    if (t ~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) { print l; exit } }
+' "$d/archive/context-log-2026.md")"
+[[ "$first_dated_heading" == "### 2026-05-28 10:00 local - codex - older work" ]] ||
+  fail "nested: archive's first dated heading must be the canonical boundary entry, got: $first_dated_heading"
 pass=$((pass + 1))
 [[ "$(count_entries "$d/log.md")" -eq 2 ]] || fail "nested: live log should keep 2 entries"
 pass=$((pass + 1))
@@ -706,5 +715,55 @@ assert_contains "$COMPACT_OUT" "Nothing to roll over" "nested no-op message"
 [[ "$(cksum "$d/log.md")" == "$before" ]] || fail "nested no-op: live log must be unchanged"
 pass=$((pass + 1))
 assert_not_exists "$d/archive/manifest.md" "nested no-op: no manifest written"
+
+# --- Existing archive with noncanonical dated entries: abort, zero writes --
+# (regression: the strict matcher made first_entry_line blind to legacy entry
+# styles, so the whole archive was treated as header prose and silently
+# reordered above the newer batch, invisible to boundary validation)
+d="$tmp_root/legacy-archive"
+mkdir -p "$d/archive"
+make_log "$d/log.md"
+cat >"$d/archive/context-log-2026.md" <<'EOF'
+# Context Log Archive
+
+## 2026-04-01 - legacy hand-written entry
+- Old-style body the strict boundary scan cannot see.
+
+### 2026-03-15 09:00 local — em-dash legacy entry
+- Body.
+EOF
+before_log="$(cksum "$d/log.md")"
+before_arch="$(cksum "$d/archive/context-log-2026.md")"
+run_compact "$d/log.md" --keep 2 --archive "$d/archive/context-log-2026.md" \
+  --manifest "$d/archive/manifest.md" --rollover-id x --require-top-entry "rollover session"
+assert_rc 1 "$COMPACT_RC" "legacy archive aborts"
+assert_contains "$COMPACT_OUT" "existing archive" "legacy archive abort message"
+[[ "$(cksum "$d/log.md")" == "$before_log" ]] || fail "legacy archive: live log must be unchanged"
+pass=$((pass + 1))
+[[ "$(cksum "$d/archive/context-log-2026.md")" == "$before_arch" ]] || fail "legacy archive: archive must be unchanged"
+pass=$((pass + 1))
+assert_not_exists "$d/archive/manifest.md" "legacy archive: no manifest written"
+
+# --- Mixed archive (noncanonical below canonical entries): same abort -------
+d="$tmp_root/mixed-archive"
+mkdir -p "$d/archive"
+make_log "$d/log.md"
+cat >"$d/archive/context-log-2026.md" <<'EOF'
+# Context Log Archive
+
+### 2026-04-02 10:00 local - claude - canonical archived entry
+- Body.
+
+## 2026-02-01 - legacy tail entry
+- Old-style body below a canonical entry.
+EOF
+before_arch="$(cksum "$d/archive/context-log-2026.md")"
+run_compact "$d/log.md" --keep 2 --archive "$d/archive/context-log-2026.md" \
+  --manifest "$d/archive/manifest.md" --rollover-id x --require-top-entry "rollover session"
+assert_rc 1 "$COMPACT_RC" "mixed archive aborts"
+assert_contains "$COMPACT_OUT" "existing archive" "mixed archive abort message"
+[[ "$(cksum "$d/archive/context-log-2026.md")" == "$before_arch" ]] || fail "mixed archive: archive must be unchanged"
+pass=$((pass + 1))
+assert_not_exists "$d/archive/manifest.md" "mixed archive: no manifest written"
 
 echo "compact-context-log compactor regression checks passed ($pass assertions)."

--- a/scripts/test-compact-context-log.sh
+++ b/scripts/test-compact-context-log.sh
@@ -655,6 +655,10 @@ make_nested_log() {
 #### 2026-05-29 follow-up
 - Fixed the import edge case later the same day; belongs to the entry above.
 
+```md
+### 2026-05-29 12:00 local - example - fenced entry heading, not a boundary
+```
+
 ### 2026-05-28 10:00 local - codex - older work
 - Body.
 


### PR DESCRIPTION
> 🤖 **Post by Claude Fable 5** · via Claude Code

## Summary

`compact-context-log.sh` and `check-context-log-rollover.sh` accepted **any** Markdown heading (any depth) whose text merely starts with a `YYYY-MM-DD` date as an entry boundary. A nested sub-heading like `#### 2026-05-29 follow-up` inside a real entry was therefore counted as another entry, with two failure modes (both reproduced before fixing):

1. **Mid-entry split**: when the nested heading lands at the keep boundary, the compactor tears its parent entry apart — the tail goes into the archive as an orphaned `####` fragment, the live copy silently loses content, and the manifest records the fragment as `newest_archived` with an inflated `archived` count. Because the checker used the same loose matcher, both the compactor's self-validation and a subsequent standalone check passed the corrupted result.
2. **Inflated trigger**: nested dated headings count toward `total_entries`, so a log with exactly `--keep` real entries rolls over when it should be a no-op — archiving *only* the orphaned fragment.

Both scripts now match the canonical `### YYYY-MM-DD HH:MM local - <agent> - <topic>` shape — the same form the tracked pre-commit hook already enforces on live entries (the hook's own matcher was already strict and is unchanged).

Found by a Codex review of a downstream scaffold sync in a private consumer repo; reproduction confirmed independently, including the no-op corruption the review did not mention.

## Files / areas changed

- `scaffold/root/scripts/compact-context-log.sh`: strict matcher in all three heading scanners — `entry_heading_lines` (split boundaries + entry count), `first_entry_line` (archive header slicing), and `select_boundaries` (manifest `newest_archived`/`oldest_archived`). The `entry_ts` 00:00 fallback became dead code under the guaranteed format and was removed (`ts = substr(line, 1, 16)`).
- `scaffold/root/scripts/check-context-log-rollover.sh`: strict matcher in `verify_archive_boundaries`, plus help text and comments — the old help explicitly documented "Entry heading styles inside `## Entries` are not constrained", which the fix supersedes for boundary verification.
- `scripts/test-compact-context-log.sh`: `count_entries` helper tightened to the same shape; new regressions — a nested dated sub-heading must stay with its kept entry (whole-entry split, correct counts, archive must not start with `####`, checker passes), and the exact-keep no-op must write nothing.
- `scripts/test-check-context-log-rollover.sh`: new regressions — a nested dated sub-heading inside an archived entry does not disturb boundary verification (positive), and a fragment-topped archive whose manifest cites the fragment as `newest_archived` fails with `newest_archived heading not found` (fail-closed).

**Review follow-up (`4d3263b`)** — closes the fail-open hole both reviews converged on:
- `scaffold/root/scripts/check-context-log-rollover.sh`: archives are now checked for dated headings the strict boundary scan cannot see — any dated heading *above* the first canonical entry is flagged as a torn-entry fragment, and any depth-1..3 noncanonical dated heading (legacy `##` style, em-dash, missing `HH:MM local -`) is flagged for normalization. Dated sub-headings of depth 4+ inside an entry remain legal body text. Help text updated.
- `scaffold/root/scripts/compact-context-log.sh`: an existing archive is validated with the checker **before any writes**; legacy/torn archives abort with a normalization pointer instead of being silently treated as header prose and reordered above the newer batch. Deliberately no override flag — an override would recreate the silent-reorder hole; normalizing the archive is the fix.
- Tests: the nested-fixture orphan assertion was hollow (`head -c 4` could never see a fragment below the `# Context Log Archive` header) and is replaced by asserting the archive's first dated heading is the canonical boundary entry; new regressions pin the legacy-only archive abort (zero writes, archive and log unchanged, no manifest), the mixed noncanonical-below-canonical abort, and checker failures for noncanonical and header-fragment archives (no manifest required).

## Design note

Full canonical-shape matching was chosen over the softer depth-3-only alternative because it aligns these scripts with the hook's enforced format and is fail-closed: a malformed heading in an archive becomes invisible to boundary selection, producing a manifest mismatch → checker failure, rather than silent corruption. Legacy em-dash (`local —`) headings live only under `## Historical Indexed Entries` wrappers outside `## Entries`, which these scanners never enter.

## Verification

Run locally (macOS, Homebrew bash 5.3):
- `bash scripts/test-compact-context-log.sh` — pass (130 assertions, including the new regressions).
- `bash scripts/test-check-context-log-rollover.sh` — pass.
- `bash scripts/test-session-metadata-hook.sh`, `bash scripts/test-memory-budget-hook.sh` — pass (hook suites exercising these scripts).
- `bash scripts/check-style.sh` — pass (ShellCheck + shfmt).
- Manual repro of both failure modes on `main`, re-run after the fix: whole entries move, counts correct, fragment archives rejected.

## Risks / rollback

- Risk: an existing hand-written or legacy archive containing noncanonical dated entry headings now fails the checker and blocks compaction with an actionable message, instead of being silently reordered (pre-review behavior) or loosely counted (pre-PR behavior). This is intended fail-closed behavior; such archives must be normalized once. Compactor-produced archives are canonical by construction.
- Rollback: revert the branch (three commits).

## Docs Consistency

- `README.md` / `docs/`: no references to the loose matcher semantics found; the checker's own `--help` text was updated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

