### PR TITLE
ci: run scaffold regression suites on macOS as well as Ubuntu

### DIFF
--- a/.github/workflows/scaffold-regression-checks.yml
+++ b/.github/workflows/scaffold-regression-checks.yml
@@ -69,10 +69,25 @@ on:
 
 jobs:
   scaffold-regression-checks:
-    runs-on: ubuntu-latest
+    strategy:
+      # Run both platforms to completion: BSD-vs-GNU userland differences are
+      # exactly what the macOS job exists to catch (a GNU-only `find -printf`
+      # once made AGENTS.md discovery silently return nothing on macOS), so an
+      # Ubuntu failure must not cancel the macOS evidence or vice versa.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Ensure bash 4+ on macOS (Apple ships bash 3.2; suites use mapfile/declare -A)
+        if: runner.os == 'macOS'
+        run: |
+          if ! bash -c '[[ ${BASH_VERSINFO[0]} -ge 4 ]]'; then
+            brew install bash
+          fi
+          bash --version | head -1
       - name: Verify managed .gitignore handling
         run: bash scripts/test-gitignore-management.sh
       - name: Verify coding standards sync behavior

--- a/.github/workflows/scaffold-regression-checks.yml
+++ b/.github/workflows/scaffold-regression-checks.yml
@@ -83,11 +83,26 @@ jobs:
         uses: actions/checkout@v4
       - name: Ensure bash 4+ on macOS (Apple ships bash 3.2; suites use mapfile/declare -A)
         if: runner.os == 'macOS'
+        # Assert against the exact Homebrew binary, not bare "bash": this
+        # step's shell hashes "bash" to /bin/bash on first use, so a bare
+        # post-install "bash --version" reports 3.2 even after a successful
+        # install and cannot prove the postcondition.
         run: |
-          if ! bash -c '[[ ${BASH_VERSINFO[0]} -ge 4 ]]'; then
+          brew_bin="$(brew --prefix)/bin"
+          if [ ! -x "$brew_bin/bash" ]; then
             brew install bash
           fi
-          bash --version | head -1
+          echo "$brew_bin" >> "$GITHUB_PATH"
+          "$brew_bin/bash" -c '[[ ${BASH_VERSINFO[0]} -ge 4 ]]'
+          "$brew_bin/bash" --version | head -1
+      - name: Verify the suite interpreter is bash 4+ (macOS)
+        if: runner.os == 'macOS'
+        # Fresh step, fresh shell: bare "bash" here resolves exactly as it
+        # will in every suite step below, so this asserts what the suites
+        # actually run with (not just that a modern bash exists somewhere).
+        run: |
+          command -v bash
+          bash -c 'echo "suite bash: $BASH_VERSION"; [[ ${BASH_VERSINFO[0]} -ge 4 ]]'
       - name: Verify managed .gitignore handling
         run: bash scripts/test-gitignore-management.sh
       - name: Verify coding standards sync behavior

--- a/README.md
+++ b/README.md
@@ -144,7 +144,11 @@ Run the scaffold regression scripts locally when changing bootstrap, sync, or tr
 - `bash scripts/test-remove-worktree.sh`
 - `bash scripts/test-worktree-helper-sync.sh`
 
-CI also runs these checks via `.github/workflows/scaffold-regression-checks.yml`.
+CI runs these checks via `.github/workflows/scaffold-regression-checks.yml` on
+both `ubuntu-latest` and `macos-latest`, so GNU-vs-BSD userland assumptions in
+the shell scripts fail in CI instead of surfacing on contributor machines.
+Locally the suites need bash 4+ (macOS ships bash 3.2 at `/bin/bash`; use
+Homebrew bash).
 
 ## Updating Existing Repos
 `update-project.sh` updates these managed scaffold files:


### PR DESCRIPTION
> 🤖 **Post by Claude Fable 5** · via Claude Code

## Summary

The scaffold regression suites ran only on `ubuntu-latest` (GNU userland). That platform gap let a BSD-incompatible `find -printf` in `check-memory-budget.sh` ship even though an existing test asserted exactly the behavior it broke — the suite failed on any stock macOS machine, but CI never executed it there. Fixed in #133; both #133 reviews endorsed a `macos-latest` job as the follow-up hardening. This PR adds it.

## Files / areas changed

- `.github/workflows/scaffold-regression-checks.yml`: the job becomes a two-leg matrix (`ubuntu-latest`, `macos-latest`) with `fail-fast: false` so one platform's failure cannot cancel the other's evidence — cross-platform divergence is precisely the signal this exists to capture. A macOS-only first step ensures bash 4+ (Apple ships 3.2 at `/bin/bash`; the suites use `mapfile`/`declare -A`), installing Homebrew bash only if the runner image lacks it. All 18 verify steps are unchanged and run identically on both legs.
- `README.md`: the Scaffold Regression Checks section now documents the two-platform CI run and the local bash 4+ requirement on macOS.

No check-name pinning concerns: the active "Protect main branch" ruleset requires PRs but names no required status checks, so the matrix rename of the check contexts is safe.

## Verification

- All 18 suites pass locally on macOS (BSD userland, Homebrew bash 5.3) — the exact environment the new leg represents; the memory-budget suite among them failed on `main` before #133, demonstrating the leg would have caught that class of bug.
- Workflow YAML parses cleanly; the matrix leg proves itself on this PR's own checks (the paths filter includes the workflow file).
- `bash scripts/check-style.sh` — pass (no shell files changed; run as regression hygiene).

## Risks / rollback

- Risk: low — additive CI leg; Ubuntu leg and step list unchanged. macOS runners are slower, so wall-clock for the workflow increases; public-repo hosted runners keep this free.
- Rollback: revert the single commit (drops the matrix back to Ubuntu-only).

## Docs Consistency

- `README.md` updated in this PR; no other docs describe CI platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)